### PR TITLE
feat: Summarize only content elements

### DIFF
--- a/app/lib/slack.test.ts
+++ b/app/lib/slack.test.ts
@@ -6,3 +6,10 @@ describe("summarize", () => {
     expect(result).toBe("hello...");
   });
 });
+
+describe("summarize", () => {
+  test("summarizes short single paragraph ignoring headers", async () => {
+    const result = summarize("# foo bar\n\nhello world!", 8);
+    expect(result).toBe("hello...");
+  });
+});

--- a/app/lib/slack.ts
+++ b/app/lib/slack.ts
@@ -11,8 +11,13 @@ export type SlackConfig = {
   iconUrl?: string;
 };
 
-export const summarize = (content: string, maxLength = 256) => {
-  const sum = sanitize(marked.parse(content, { breaks: true }), {
+export const summarize = (content: string, maxLength = 256): string => {
+  // first remove elements we wouldn't want as a summary
+  const contentBlocks = sanitize(marked.parse(content, { breaks: true }), {
+    ALLOWED_TAGS: ["p", "blockquote", "#text"],
+    KEEP_CONTENT: false,
+  });
+  const sum = sanitize(contentBlocks, {
     ALLOWED_TAGS: [],
   }).replace(/^[\s\n]+|[\s\n]+$/g, "");
   if (sum.length > maxLength)


### PR DESCRIPTION
Avoid summarizing common leading elements like headers, and instead only use content from tags such as paragraph and blockquote.

Fixes #24