### PR TITLE
Allow drafts to be fetched by default

### DIFF
--- a/app/entry.client.tsx
+++ b/app/entry.client.tsx
@@ -12,11 +12,11 @@ Sentry.init({
   tracesSampleRate: 1.0,
   integrations: [
     new Sentry.BrowserTracing({
-        routingInstrumentation: Sentry.remixRouterInstrumentation(
-            useEffect,
-            useLocation,
-            useMatches,
-        ),
+      routingInstrumentation: Sentry.remixRouterInstrumentation(
+        useEffect,
+        useLocation,
+        useMatches
+      ),
     }),
   ],
 });

--- a/app/routes/u/$userEmail.tsx
+++ b/app/routes/u/$userEmail.tsx
@@ -139,7 +139,7 @@ const PostList = styled.div`
 
 const PostCardTitle = styled.h2`
   font-family: "Gazpacho-Heavy", serif;
-`
+`;
 
 const PostCard = styled.div`
   background: ${(p) => p.theme.bgColor};


### PR DESCRIPTION
This aids the draft process, and lets you link a draft to someone directly, but still avoids them showing up in post lists.