### PR TITLE
fix: Layer the primary content above the sidebar background

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -265,6 +265,8 @@ const Primary = styled.div`
     width: 80%;
     padding: 0 5rem;
     margin-right: 40rem;
+    position: relative;
+    z-index: 1;
   `}
 `;
 


### PR DESCRIPTION
The layers stack up when the window is about 1025px wide to 1200px.

| Before  | After |
| ------------- | ------------- |
| <img width="200" alt="Screen Shot 2022-08-17 at 2 09 42 PM" src="https://user-images.githubusercontent.com/187460/185244143-c70ed2ba-d34e-467f-bc79-54db5b7d3b17.png">  | <img width="200" alt="Screen Shot 2022-08-17 at 2 09 31 PM" src="https://user-images.githubusercontent.com/187460/185244150-dc58fb95-5c9f-41d9-a1ad-c43b047acf6f.png"> |

Ultrawide monitors at home could work, but then i'd need a bigger desk + bigger room and in SFO that's crazy.