### PR TITLE
feat: Add notifications for comment replies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,5 @@ SMTP_HOST=
 SMTP_PORT=
 SMTP_USER=
 SMTP_PASS=
+# only used in development
+DUMMY_USER_EMAIL=

--- a/app/components/editor.tsx
+++ b/app/components/editor.tsx
@@ -165,6 +165,7 @@ const EditorWrapper = styled.div`
   textarea {
     width: 100%;
     border-radius: 0 0 6px 6px;
+    padding: 5px;
     border: 1px solid ${(p) => p.theme.borderColor};
   }
 `;

--- a/app/components/post-comments.tsx
+++ b/app/components/post-comments.tsx
@@ -277,7 +277,7 @@ export default ({
             post={post}
             inReplyTo={inReplyTo}
             onInReplyTo={(comment) => setInReplyTo(comment || null)}
-            onComment={(comment) => setCommentList([...comments, comment])}
+            onComment={(comment) => setCommentList([...commentList, comment])}
           />
         ) : (
           <p>Comments are disabled for this post.</p>

--- a/app/lib/iap.ts
+++ b/app/lib/iap.ts
@@ -64,12 +64,11 @@ async function verifyGoogleToken(token: string) {
 
 export async function getIdentity(request: Request): Promise<Identity | null> {
   if (process.env.NODE_ENV !== "production") {
-    console.log(
-      "Dev environment bypassing authentication as jane.doe@example.com"
-    );
+    const email = process.env.DUMMY_USER_EMAIL || "jane.doe@example.com";
+    console.log(`Dev environment bypassing authentication as ${email}`);
     return {
       id: "dummy-iap-user",
-      email: "jane.doe@example.com",
+      email,
     };
   }
 

--- a/app/lib/slack.ts
+++ b/app/lib/slack.ts
@@ -1,8 +1,7 @@
 import { error } from "./logging";
 import type { PostQueryType } from "~/models/post.server";
 import moment from "moment";
-import { marked } from "marked";
-import { sanitize } from "isomorphic-dompurify";
+import summarize from "./summarize";
 
 export type SlackConfig = {
   webhookUrl: string;
@@ -11,21 +10,13 @@ export type SlackConfig = {
   iconUrl?: string;
 };
 
-export const summarize = (content: string, maxLength = 256): string => {
-  // first remove elements we wouldn't want as a summary
-  const contentBlocks = sanitize(marked.parse(content, { breaks: true }), {
-    ALLOWED_TAGS: ["p", "blockquote", "#text"],
-    KEEP_CONTENT: false,
-  });
-  const sum = sanitize(contentBlocks, {
-    ALLOWED_TAGS: [],
-  }).replace(/^[\s\n]+|[\s\n]+$/g, "");
-  if (sum.length > maxLength)
-    return sum.substring(0, maxLength - 3).split("\n")[0] + "...";
-  return sum;
-};
-
-export const notify = async (post: PostQueryType, config: SlackConfig) => {
+export const notify = async ({
+  post,
+  config,
+}: {
+  post: PostQueryType;
+  config: SlackConfig;
+}) => {
   const { author, category } = post;
   console.log(`Sending Slack notification for post ${post.id}`);
 

--- a/app/lib/summarize.test.ts
+++ b/app/lib/summarize.test.ts
@@ -1,4 +1,4 @@
-import { summarize } from "~/lib/slack";
+import summarize from "./summarize";
 
 describe("summarize", () => {
   test("summarizes short single paragraph ignoring images", async () => {

--- a/app/lib/summarize.ts
+++ b/app/lib/summarize.ts
@@ -1,0 +1,16 @@
+import { marked } from "marked";
+import { sanitize } from "isomorphic-dompurify";
+
+export default (content: string, maxLength = 256): string => {
+  // first remove elements we wouldn't want as a summary
+  const contentBlocks = sanitize(marked.parse(content, { breaks: true }), {
+    ALLOWED_TAGS: ["p", "blockquote", "#text", "strong", "b", "em", "i", "a"],
+    KEEP_CONTENT: false,
+  });
+  const sum = sanitize(contentBlocks, {
+    ALLOWED_TAGS: [],
+  }).replace(/^[\s\n]+|[\s\n]+$/g, "");
+  if (sum.length > maxLength)
+    return sum.substring(0, maxLength - 3).split("\n")[0] + "...";
+  return sum;
+};

--- a/app/lib/test.html
+++ b/app/lib/test.html
@@ -1,0 +1,50 @@
+<div style="background: #f7f6fa">
+  <div
+    style="
+      padding: 15px;
+      background: #fff;
+      border: 1px solid #d0cbdf;
+      margin-bottom: 15px;
+    "
+  >
+    <h2 style="margin: 0 0 15px; color: #1d142a">
+      David Cramer left a new comment
+    </h2>
+
+    <table>
+      <tr>
+        <td rowspan="3" style="vertical-align: top">
+          <img
+            src="http://localhost:3000/img/placeholder-avatar.png"
+            width="36"
+            height="36"
+            style="border-radius: 36px"
+          />
+        </td>
+        <td style="padding-left: 15px">
+          <strong style="color: #1d142a">David Cramer</strong>
+        </td>
+      </tr>
+      <tr>
+        <td style="color: #60557f; padding-left: 15px">
+          What about with a background?
+        </td>
+      </tr>
+      <tr>
+        <td style="padding-left: 15px">
+          <a
+            href="http://localhost:3000/p/cl70oz4g40393o2laf7bv9kv5#c_cl70pxxhk4934o2lakdcpofy4"
+            style="color: #f0345f"
+            >View this Comment</a
+          >
+        </td>
+      </tr>
+    </table>
+  </div>
+  <p style="color: #60557f; margin: 0">
+    You are being notified because you are subscribed to this post.
+    <a href="http://localhost:3000/p/cl70oz4g40393o2laf7bv9kv5"
+      >Post Settings</a
+    >
+  </p>
+</div>

--- a/app/models/post.server.ts
+++ b/app/models/post.server.ts
@@ -32,7 +32,10 @@ export async function announcePost(post: PostQueryType) {
   });
 
   emailConfig.forEach(async (config) => {
-    await email.notify(post, config as email.EmailConfig);
+    await email.notify({
+      post,
+      config: config as email.EmailConfig,
+    });
   });
 
   let slackConfig: slack.SlackConfig[] | CategorySlack[] =
@@ -51,7 +54,10 @@ export async function announcePost(post: PostQueryType) {
   }
 
   slackConfig.forEach(async (config) => {
-    await slack.notify(post, config as slack.SlackConfig);
+    await slack.notify({
+      post,
+      config: config as slack.SlackConfig,
+    });
   });
 }
 

--- a/app/routes/settings.tsx
+++ b/app/routes/settings.tsx
@@ -47,6 +47,7 @@ export const action: ActionFunction = async ({ request }) => {
     })
   );
   const name = formData.get("name");
+  const notifyReplies = !!formData.get("notifyReplies");
   let picture: any = formData.get("picture");
   // empty values get returned as empty strings, which will unset
   // the picture rather than leave it unchanged
@@ -64,6 +65,7 @@ export const action: ActionFunction = async ({ request }) => {
     id: userId,
     name,
     picture,
+    notifyReplies,
   });
 
   const url = new URL(request.url);
@@ -136,6 +138,16 @@ export default function NewPostPage() {
             {errors.picture}
           </div>
         )}
+      </div>
+      <div>
+        <label className="field-inline">
+          <input
+            type="checkbox"
+            name="notifyReplies"
+            defaultChecked={user.notifyReplies}
+          />
+          Receive notifications about replies to your comments?
+        </label>
       </div>
       <FormActions>
         <Button type="submit" mode="primary">

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:server": "esbuild --platform=node --bundle --format=cjs ./server --outdir=build --sourcemap=external",
     "build:sourcemaps": "sentry-upload-sourcemaps",
     "db:migrate": "run-p db:migrate:*",
-    "db:migrate:dev": "npx prisma migrate dev",
+    "db:migrate:dev": "npx prisma migrate dev && npx prisma db seed",
     "db:migrate:test": "dotenv -e .env.test -- npx prisma db push --accept-data-loss",
     "dev": "run-p dev:*",
     "dev:server": "cross-env NODE_ENV=development node --inspect --require ./node_modules/dotenv/config --require ./mocks ./build/server.js",

--- a/prisma/migrations/20220819162059_add_notify_replies/migration.sql
+++ b/prisma/migrations/20220819162059_add_notify_replies/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "notifyReplies" BOOLEAN NOT NULL DEFAULT true;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,6 +20,7 @@ model User {
   posts             Post[]
   canPostRestricted Boolean            @default(false)
   admin             Boolean            @default(false)
+  notifyReplies     Boolean            @default(true)
   PostComment       PostComment[]
   PostRevision      PostRevision[]
   PostReaction      PostReaction[]

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -2,30 +2,7 @@ import { PrismaClient } from "@prisma/client";
 
 const prisma = new PrismaClient();
 
-const ADMINS = [
-  ["david@sentry.io", "David Cramer"],
-  ["chris@sentry.io", "Chris Jennings"],
-];
-
 async function main() {
-  let adminsByEmail: { [email: string]: any } = {};
-
-  ADMINS.forEach(async ([email, name]) => {
-    adminsByEmail[email] = await prisma.user.upsert({
-      where: { email },
-      update: {
-        canPostRestricted: true,
-        admin: true,
-      },
-      create: {
-        email,
-        name,
-        canPostRestricted: true,
-        admin: true,
-      },
-    });
-  });
-
   await prisma.category.upsert({
     where: { name: "Shipped" },
     update: {


### PR DESCRIPTION
Notify the original comment author about replies (by default).

Adds a new option 'notifyReplies' available via the user settings to disable this.

Also cleans up various email notification behaviors and design.

Fixes GH-68