### PR TITLE
feat: Allow unauthenticated feeds

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,4 +24,5 @@ SMTP_PORT=
 SMTP_USER=
 SMTP_PASS=
 # only used in development
+IAP_DUMMY_USER=1
 DUMMY_USER_EMAIL=

--- a/.env.test
+++ b/.env.test
@@ -1,2 +1,3 @@
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/test_vanguard
 SESSION_SECRET=insecure-af
+IAP_DUMMY_USER=

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ export const action: ActionFunction = async ({ request }) => {
 };
 ```
 
+All endpoints which require auth must also contain a test asserting that authentication is enforced.
+
 ## Testing
 
 ### Vitest

--- a/README.md
+++ b/README.md
@@ -51,6 +51,24 @@ It is built on top of [Remix](https://github.com/remix-run/remix), and intended 
   npm run dev
   ```
 
+### Authentication
+
+Authentication is enforced per-route via the Remix loaders. All routes **must** enforce authentication unless they are intended to be publicly accessible.
+
+```typescript
+export const loader: LoaderFunction = async ({ request }) => {
+  await requireUserId(request);
+};
+```
+
+If you are also using actions on the route, you need to define the same check in the action:
+
+```typescript
+export const action: ActionFunction = async ({ request }) => {
+  await requireUserId(request);
+};
+```
+
 ## Testing
 
 ### Vitest

--- a/app/lib/__mocks__/iap.ts
+++ b/app/lib/__mocks__/iap.ts
@@ -1,0 +1,28 @@
+import * as iap from "~/lib/iap";
+
+let currentIdentity: any = null;
+
+export const getIdentity = async (request: Request) => {
+  return currentIdentity;
+};
+
+export const setTestIdentity = (identity: iap.Identity | null = null) => {
+  currentIdentity = identity;
+};
+
+export const setDefaultIdentity = () => {
+  currentIdentity = DefaultIdentity;
+};
+
+export const DefaultIdentity = {
+  email: "test-iap-user@example.com",
+  id: "test-iap-user",
+};
+
+// vi.mock("~/lib/iap", async () => {
+//   const mod = await vi.importActual<typeof import("~/lib/iap")>("~/lib/iap");
+//   return {
+//     ...mod,
+//     mocked: vi.fn(),
+//   };
+// });

--- a/app/lib/__mocks__/iap.ts
+++ b/app/lib/__mocks__/iap.ts
@@ -18,11 +18,3 @@ export const DefaultTestIdentity = {
   email: "test-iap-user@example.com",
   id: "test-iap-user",
 };
-
-// vi.mock("~/lib/iap", async () => {
-//   const mod = await vi.importActual<typeof import("~/lib/iap")>("~/lib/iap");
-//   return {
-//     ...mod,
-//     mocked: vi.fn(),
-//   };
-// });

--- a/app/lib/__mocks__/iap.ts
+++ b/app/lib/__mocks__/iap.ts
@@ -10,11 +10,11 @@ export const setTestIdentity = (identity: iap.Identity | null = null) => {
   currentIdentity = identity;
 };
 
-export const setDefaultIdentity = () => {
-  currentIdentity = DefaultIdentity;
+export const setDefaultTestIdentity = () => {
+  currentIdentity = DefaultTestIdentity;
 };
 
-export const DefaultIdentity = {
+export const DefaultTestIdentity = {
   email: "test-iap-user@example.com",
   id: "test-iap-user",
 };

--- a/app/lib/iap.ts
+++ b/app/lib/iap.ts
@@ -68,7 +68,7 @@ async function verifyGoogleToken(token: string): Promise<GoogleJwtPayload> {
 }
 
 export async function getIdentity(request: Request): Promise<Identity | null> {
-  if (process.env.NODE_ENV !== "production") {
+  if (process.env.NODE_ENV !== "production" && process.env.IAP_DUMMY_USER) {
     const email = process.env.DUMMY_USER_EMAIL || "jane.doe@example.com";
     console.log(`Dev environment bypassing authentication as ${email}`);
     return {

--- a/app/lib/test/expects.ts
+++ b/app/lib/test/expects.ts
@@ -1,0 +1,27 @@
+import { expect } from "vitest";
+
+expect.extend({
+  async toThrowErrorMatching(error, expected) {
+    const pass = expected(error);
+    return {
+      pass,
+      message: () => `we failed`,
+    };
+  },
+});
+
+export const expectRequiresAdmin = async (cb) => {
+  await expect(cb).rejects.toThrowErrorMatching((err) => {
+    expect(err.status).toBe(302);
+    expect(err.headers.get("location").split("?")[0]).toBe("/401");
+    return true;
+  });
+};
+
+export const expectRequiresUser = async (cb) => {
+  await expect(cb).rejects.toThrowErrorMatching((err) => {
+    expect(err.status).toBe(302);
+    expect(err.headers.get("location").split("?")[0]).toBe("/401");
+    return true;
+  });
+};

--- a/app/lib/test/expects.ts
+++ b/app/lib/test/expects.ts
@@ -10,10 +10,12 @@ expect.extend({
   },
 });
 
-export const expectRequiresAdmin = async (cb) => {
+export const expectRequiresAdmin = async (cb, existingUser = true) => {
   await expect(cb).rejects.toThrowErrorMatching((err) => {
     expect(err.status).toBe(302);
-    expect(err.headers.get("location").split("?")[0]).toBe("/401");
+    expect(err.headers.get("location").split("?")[0]).toBe(
+      existingUser ? "/403" : "/401"
+    );
     return true;
   });
 };

--- a/app/models/post.server.ts
+++ b/app/models/post.server.ts
@@ -105,7 +105,7 @@ export async function getPostList({
   offset = 0,
   limit = 50,
 }: {
-  userId: User["id"];
+  userId?: User["id"];
   published?: boolean | null;
   authorId?: User["id"];
   categoryId?: Category["id"];
@@ -115,14 +115,19 @@ export async function getPostList({
   offset?: number;
   limit?: number;
 }): Promise<PostQueryType[]> {
-  const user = await prisma.user.findFirst({ where: { id: userId } });
-  invariant(user, "user not found");
+  const user = userId
+    ? await prisma.user.findFirst({ where: { id: userId } })
+    : null;
+
+  if (!user && !feedId) {
+    throw new Error("Cannot query posts without either userId or feedId");
+  }
 
   const where: { [key: string]: any } = { deleted: false };
   if (published !== undefined) {
     where.published = published;
   }
-  if (where.published !== true && !user.admin) {
+  if (where.published !== true && !user?.admin) {
     where.authorId = userId;
   }
   if (authorId) {

--- a/app/routes/admin/categories/$categoryId.test.ts
+++ b/app/routes/admin/categories/$categoryId.test.ts
@@ -1,0 +1,45 @@
+import { expectRequiresAdmin } from "~/lib/test/expects";
+import { setDefaultTestIdentity } from "~/lib/__mocks__/iap";
+import * as Fixtures from "~/lib/test/fixtures";
+
+import { action, loader } from "./$categoryId";
+
+describe("GET /admin/categories/$categoryId", () => {
+  it("requires admin", async () => {
+    const category = await Fixtures.Category();
+    setDefaultTestIdentity();
+
+    await expectRequiresAdmin(
+      loader({
+        request: new Request(
+          `http://localhost/admin/categories/${category.id}`,
+          {
+            method: "GET",
+          }
+        ),
+        params: { categoryId: category.id },
+        context: {},
+      })
+    );
+  });
+});
+
+describe("POST /admin/categories/$categoryId", () => {
+  it("requires admin", async () => {
+    const category = await Fixtures.Category();
+    setDefaultTestIdentity();
+
+    await expectRequiresAdmin(
+      action({
+        request: new Request(
+          `http://localhost/admin/categories/${category.id}`,
+          {
+            method: "POST",
+          }
+        ),
+        params: { categoryId: category.id },
+        context: {},
+      })
+    );
+  });
+});

--- a/app/routes/admin/categories/index.test.ts
+++ b/app/routes/admin/categories/index.test.ts
@@ -1,8 +1,11 @@
 import { expectRequiresAdmin } from "~/lib/test/expects";
+import { setDefaultIdentity } from "~/lib/__mocks__/iap";
 import { loader } from ".";
 
 describe("/admin/categories/", () => {
   it("requires admin", async () => {
+    setDefaultIdentity();
+
     await expectRequiresAdmin(
       loader({
         request: new Request(`http://localhost/admin/categories/`, {

--- a/app/routes/admin/categories/index.test.ts
+++ b/app/routes/admin/categories/index.test.ts
@@ -1,10 +1,10 @@
 import { expectRequiresAdmin } from "~/lib/test/expects";
-import { setDefaultIdentity } from "~/lib/__mocks__/iap";
+import { setDefaultTestIdentity } from "~/lib/__mocks__/iap";
 import { loader } from ".";
 
 describe("/admin/categories/", () => {
   it("requires admin", async () => {
-    setDefaultIdentity();
+    setDefaultTestIdentity();
 
     await expectRequiresAdmin(
       loader({

--- a/app/routes/admin/categories/index.test.ts
+++ b/app/routes/admin/categories/index.test.ts
@@ -1,0 +1,16 @@
+import { expectRequiresAdmin } from "~/lib/test/expects";
+import { loader } from ".";
+
+describe("/admin/categories/", () => {
+  it("requires admin", async () => {
+    await expectRequiresAdmin(
+      loader({
+        request: new Request(`http://localhost/admin/categories/`, {
+          method: "GET",
+        }),
+        params: {},
+        context: {},
+      })
+    );
+  });
+});

--- a/app/routes/admin/categories/index.test.ts
+++ b/app/routes/admin/categories/index.test.ts
@@ -2,7 +2,7 @@ import { expectRequiresAdmin } from "~/lib/test/expects";
 import { setDefaultTestIdentity } from "~/lib/__mocks__/iap";
 import { loader } from ".";
 
-describe("/admin/categories/", () => {
+describe("GET /admin/categories/", () => {
   it("requires admin", async () => {
     setDefaultTestIdentity();
 

--- a/app/routes/admin/categories/new.test.ts
+++ b/app/routes/admin/categories/new.test.ts
@@ -1,0 +1,39 @@
+import { expectRequiresAdmin } from "~/lib/test/expects";
+import { setDefaultTestIdentity } from "~/lib/__mocks__/iap";
+import * as Fixtures from "~/lib/test/fixtures";
+
+import { loader, action } from "./new";
+
+describe("GET /admin/categories/new", () => {
+  it("requires admin", async () => {
+    const category = Fixtures.Category();
+    setDefaultTestIdentity();
+
+    await expectRequiresAdmin(
+      loader({
+        request: new Request(`http://localhost/admin/categories/new`, {
+          method: "GET",
+        }),
+        params: {},
+        context: {},
+      })
+    );
+  });
+});
+
+describe("POST /admin/categories/new", () => {
+  it("requires admin", async () => {
+    const category = Fixtures.Category();
+    setDefaultTestIdentity();
+
+    await expectRequiresAdmin(
+      action({
+        request: new Request(`http://localhost/admin/categories/new`, {
+          method: "POST",
+        }),
+        params: {},
+        context: {},
+      })
+    );
+  });
+});

--- a/app/routes/admin/categories/new.tsx
+++ b/app/routes/admin/categories/new.tsx
@@ -1,4 +1,4 @@
-import type { ActionFunction } from "@remix-run/node";
+import type { ActionFunction, LoaderFunction } from "@remix-run/node";
 import { json, redirect } from "@remix-run/node";
 import { Form, useActionData } from "@remix-run/react";
 
@@ -19,6 +19,10 @@ type ActionData = {
       to?: string;
     };
   };
+};
+
+export const loader: LoaderFunction = async ({ request }) => {
+  await requireAdmin(request);
 };
 
 export const action: ActionFunction = async ({ request, params }) => {

--- a/app/routes/admin/comments/index.test.ts
+++ b/app/routes/admin/comments/index.test.ts
@@ -1,0 +1,16 @@
+import { expectRequiresAdmin } from "~/lib/test/expects";
+import { loader } from ".";
+
+describe("/admin/comments/", () => {
+  it("requires admin", async () => {
+    await expectRequiresAdmin(
+      loader({
+        request: new Request(`http://localhost/admin/comments/`, {
+          method: "GET",
+        }),
+        params: {},
+        context: {},
+      })
+    );
+  });
+});

--- a/app/routes/admin/comments/index.test.ts
+++ b/app/routes/admin/comments/index.test.ts
@@ -1,10 +1,10 @@
 import { expectRequiresAdmin } from "~/lib/test/expects";
-import { setDefaultIdentity } from "~/lib/__mocks__/iap";
+import { setDefaultTestIdentity } from "~/lib/__mocks__/iap";
 import { loader } from ".";
 
 describe("/admin/comments/", () => {
   it("requires admin", async () => {
-    setDefaultIdentity();
+    setDefaultTestIdentity();
 
     await expectRequiresAdmin(
       loader({

--- a/app/routes/admin/comments/index.test.ts
+++ b/app/routes/admin/comments/index.test.ts
@@ -1,8 +1,11 @@
 import { expectRequiresAdmin } from "~/lib/test/expects";
+import { setDefaultIdentity } from "~/lib/__mocks__/iap";
 import { loader } from ".";
 
 describe("/admin/comments/", () => {
   it("requires admin", async () => {
+    setDefaultIdentity();
+
     await expectRequiresAdmin(
       loader({
         request: new Request(`http://localhost/admin/comments/`, {

--- a/app/routes/admin/feeds/$feedId.test.ts
+++ b/app/routes/admin/feeds/$feedId.test.ts
@@ -1,0 +1,39 @@
+import { expectRequiresAdmin } from "~/lib/test/expects";
+import { setDefaultTestIdentity } from "~/lib/__mocks__/iap";
+import * as Fixtures from "~/lib/test/fixtures";
+
+import { action, loader } from "./$feedId";
+
+describe("GET /admin/feeds/$feedId", () => {
+  it("requires admin", async () => {
+    const feed = await Fixtures.Feed();
+    setDefaultTestIdentity();
+
+    await expectRequiresAdmin(
+      loader({
+        request: new Request(`http://localhost/admin/feeds/${feed.id}`, {
+          method: "GET",
+        }),
+        params: { feedId: feed.id },
+        context: {},
+      })
+    );
+  });
+});
+
+describe("POST /admin/feeds/$feedId", () => {
+  it("requires admin", async () => {
+    const feed = await Fixtures.Feed();
+    setDefaultTestIdentity();
+
+    await expectRequiresAdmin(
+      action({
+        request: new Request(`http://localhost/admin/feeds/${feed.id}`, {
+          method: "POST",
+        }),
+        params: { feedId: feed.id },
+        context: {},
+      })
+    );
+  });
+});

--- a/app/routes/admin/feeds/index.test.ts
+++ b/app/routes/admin/feeds/index.test.ts
@@ -1,0 +1,16 @@
+import { expectRequiresAdmin } from "~/lib/test/expects";
+import { loader } from ".";
+
+describe("/admin/feeds/", () => {
+  it("requires admin", async () => {
+    await expectRequiresAdmin(
+      loader({
+        request: new Request(`http://localhost/admin/feeds/`, {
+          method: "GET",
+        }),
+        params: {},
+        context: {},
+      })
+    );
+  });
+});

--- a/app/routes/admin/feeds/index.test.ts
+++ b/app/routes/admin/feeds/index.test.ts
@@ -1,10 +1,10 @@
 import { expectRequiresAdmin } from "~/lib/test/expects";
-import { setDefaultIdentity } from "~/lib/__mocks__/iap";
+import { setDefaultTestIdentity } from "~/lib/__mocks__/iap";
 import { loader } from ".";
 
 describe("/admin/feeds/", () => {
   it("requires admin", async () => {
-    setDefaultIdentity();
+    setDefaultTestIdentity();
 
     await expectRequiresAdmin(
       loader({

--- a/app/routes/admin/feeds/index.test.ts
+++ b/app/routes/admin/feeds/index.test.ts
@@ -1,8 +1,11 @@
 import { expectRequiresAdmin } from "~/lib/test/expects";
+import { setDefaultIdentity } from "~/lib/__mocks__/iap";
 import { loader } from ".";
 
 describe("/admin/feeds/", () => {
   it("requires admin", async () => {
+    setDefaultIdentity();
+
     await expectRequiresAdmin(
       loader({
         request: new Request(`http://localhost/admin/feeds/`, {

--- a/app/routes/admin/feeds/index.test.ts
+++ b/app/routes/admin/feeds/index.test.ts
@@ -2,7 +2,7 @@ import { expectRequiresAdmin } from "~/lib/test/expects";
 import { setDefaultTestIdentity } from "~/lib/__mocks__/iap";
 import { loader } from ".";
 
-describe("/admin/feeds/", () => {
+describe("GET /admin/feeds/", () => {
   it("requires admin", async () => {
     setDefaultTestIdentity();
 

--- a/app/routes/admin/feeds/new.test.ts
+++ b/app/routes/admin/feeds/new.test.ts
@@ -1,0 +1,36 @@
+import { expectRequiresAdmin } from "~/lib/test/expects";
+import { setDefaultTestIdentity } from "~/lib/__mocks__/iap";
+
+import { action, loader } from "./new";
+
+describe("GET /admin/feeds/$feedId", () => {
+  it("requires admin", async () => {
+    setDefaultTestIdentity();
+
+    await expectRequiresAdmin(
+      loader({
+        request: new Request(`http://localhost/admin/feeds/new`, {
+          method: "GET",
+        }),
+        params: {},
+        context: {},
+      })
+    );
+  });
+});
+
+describe("POST /admin/feeds/$feedId", () => {
+  it("requires admin", async () => {
+    setDefaultTestIdentity();
+
+    await expectRequiresAdmin(
+      action({
+        request: new Request(`http://localhost/admin/feeds/new`, {
+          method: "POST",
+        }),
+        params: {},
+        context: {},
+      })
+    );
+  });
+});

--- a/app/routes/admin/feeds/new.tsx
+++ b/app/routes/admin/feeds/new.tsx
@@ -21,6 +21,10 @@ type ActionData = {
   };
 };
 
+export const loader: LoaderFunction = async ({ request }) => {
+  await requireAdmin(request);
+};
+
 export const action: ActionFunction = async ({ request, params }) => {
   await requireAdmin(request);
   const formData = await request.formData();

--- a/app/routes/admin/index.test.ts
+++ b/app/routes/admin/index.test.ts
@@ -1,10 +1,10 @@
 import { expectRequiresAdmin } from "~/lib/test/expects";
-import { setDefaultIdentity } from "~/lib/__mocks__/iap";
+import { setDefaultTestIdentity } from "~/lib/__mocks__/iap";
 import { loader } from ".";
 
 describe("/admin/", () => {
   it("requires admin", async () => {
-    setDefaultIdentity();
+    setDefaultTestIdentity();
 
     await expectRequiresAdmin(
       loader({

--- a/app/routes/admin/index.test.ts
+++ b/app/routes/admin/index.test.ts
@@ -1,8 +1,11 @@
 import { expectRequiresAdmin } from "~/lib/test/expects";
+import { setDefaultIdentity } from "~/lib/__mocks__/iap";
 import { loader } from ".";
 
 describe("/admin/", () => {
   it("requires admin", async () => {
+    setDefaultIdentity();
+
     await expectRequiresAdmin(
       loader({
         request: new Request(`http://localhost/admin/`, {

--- a/app/routes/admin/index.test.ts
+++ b/app/routes/admin/index.test.ts
@@ -2,7 +2,7 @@ import { expectRequiresAdmin } from "~/lib/test/expects";
 import { setDefaultTestIdentity } from "~/lib/__mocks__/iap";
 import { loader } from ".";
 
-describe("/admin/", () => {
+describe("GET /admin/", () => {
   it("requires admin", async () => {
     setDefaultTestIdentity();
 

--- a/app/routes/admin/index.test.ts
+++ b/app/routes/admin/index.test.ts
@@ -1,0 +1,16 @@
+import { expectRequiresAdmin } from "~/lib/test/expects";
+import { loader } from ".";
+
+describe("/admin/", () => {
+  it("requires admin", async () => {
+    await expectRequiresAdmin(
+      loader({
+        request: new Request(`http://localhost/admin/`, {
+          method: "GET",
+        }),
+        params: {},
+        context: {},
+      })
+    );
+  });
+});

--- a/app/routes/admin/posts/index.test.ts
+++ b/app/routes/admin/posts/index.test.ts
@@ -1,8 +1,11 @@
 import { expectRequiresAdmin } from "~/lib/test/expects";
+import { setDefaultIdentity } from "~/lib/__mocks__/iap";
 import { loader } from ".";
 
 describe("/admin/posts/", () => {
   it("requires admin", async () => {
+    setDefaultIdentity();
+
     await expectRequiresAdmin(
       loader({
         request: new Request(`http://localhost/admin/posts/`, {

--- a/app/routes/admin/posts/index.test.ts
+++ b/app/routes/admin/posts/index.test.ts
@@ -2,7 +2,7 @@ import { expectRequiresAdmin } from "~/lib/test/expects";
 import { setDefaultTestIdentity } from "~/lib/__mocks__/iap";
 import { loader } from ".";
 
-describe("/admin/posts/", () => {
+describe("GET /admin/posts/", () => {
   it("requires admin", async () => {
     setDefaultTestIdentity();
 

--- a/app/routes/admin/posts/index.test.ts
+++ b/app/routes/admin/posts/index.test.ts
@@ -1,0 +1,16 @@
+import { expectRequiresAdmin } from "~/lib/test/expects";
+import { loader } from ".";
+
+describe("/admin/posts/", () => {
+  it("requires admin", async () => {
+    await expectRequiresAdmin(
+      loader({
+        request: new Request(`http://localhost/admin/posts/`, {
+          method: "GET",
+        }),
+        params: {},
+        context: {},
+      })
+    );
+  });
+});

--- a/app/routes/admin/posts/index.test.ts
+++ b/app/routes/admin/posts/index.test.ts
@@ -1,10 +1,10 @@
 import { expectRequiresAdmin } from "~/lib/test/expects";
-import { setDefaultIdentity } from "~/lib/__mocks__/iap";
+import { setDefaultTestIdentity } from "~/lib/__mocks__/iap";
 import { loader } from ".";
 
 describe("/admin/posts/", () => {
   it("requires admin", async () => {
-    setDefaultIdentity();
+    setDefaultTestIdentity();
 
     await expectRequiresAdmin(
       loader({

--- a/app/routes/admin/users/index.test.ts
+++ b/app/routes/admin/users/index.test.ts
@@ -2,13 +2,13 @@ import { expectRequiresAdmin } from "~/lib/test/expects";
 import { setDefaultTestIdentity } from "~/lib/__mocks__/iap";
 import { loader } from ".";
 
-describe("GET /admin/comments/", () => {
+describe("GET /admin/users/", () => {
   it("requires admin", async () => {
     setDefaultTestIdentity();
 
     await expectRequiresAdmin(
       loader({
-        request: new Request(`http://localhost/admin/comments/`, {
+        request: new Request(`http://localhost/admin/users/`, {
           method: "GET",
         }),
         params: {},

--- a/app/routes/api/posts/$postId/comments/$commentId.test.ts
+++ b/app/routes/api/posts/$postId/comments/$commentId.test.ts
@@ -1,0 +1,39 @@
+import type { Post, User } from "@prisma/client";
+import { setDefaultTestIdentity, setTestIdentity } from "~/lib/__mocks__/iap";
+import { expectRequiresUser } from "~/lib/test/expects";
+import * as Fixtures from "~/lib/test/fixtures";
+
+import { action } from "./$commentId";
+
+describe("DELETE /api/posts/$postId/subscription", () => {
+  let author: User;
+  let post: Post;
+
+  beforeEach(async () => {
+    author = await Fixtures.User();
+    post = await Fixtures.Post({
+      authorId: author.id,
+    });
+  });
+
+  beforeEach(() => {
+    setDefaultTestIdentity();
+  });
+
+  it("requires user", async () => {
+    const comment = await Fixtures.PostComment();
+    setTestIdentity(null);
+    await expectRequiresUser(
+      action({
+        request: new Request(
+          `http://localhost/api/posts/${post.id}/comments/${comment.id}`,
+          {
+            method: "DELETE",
+          }
+        ),
+        params: { postId: post.id, commentId: comment.id },
+        context: {},
+      })
+    );
+  });
+});

--- a/app/routes/api/posts/$postId/comments/index.test.ts
+++ b/app/routes/api/posts/$postId/comments/index.test.ts
@@ -1,0 +1,18 @@
+import { expectRequiresUser } from "~/lib/test/expects";
+import * as Fixtures from "~/lib/test/fixtures";
+import { action } from ".";
+
+describe("POST /api/posts/$postId/comments", () => {
+  it("requires user", async () => {
+    const post = await Fixtures.Post();
+    await expectRequiresUser(
+      action({
+        request: new Request(`http://localhost/api/posts/${post.id}/comments`, {
+          method: "POST",
+        }),
+        params: { postId: post.id },
+        context: {},
+      })
+    );
+  });
+});

--- a/app/routes/api/posts/$postId/reactions.test.ts
+++ b/app/routes/api/posts/$postId/reactions.test.ts
@@ -39,6 +39,7 @@ describe("post reactions action", () => {
       request: new Request(`http://localhost/api/posts/${post.id}/reactions`, {
         method: "POST",
         body: JSON.stringify({ emoji: HEART }),
+        headers: {},
       }),
       params: { postId: post.id },
       context: {},

--- a/app/routes/api/posts/$postId/reactions.test.ts
+++ b/app/routes/api/posts/$postId/reactions.test.ts
@@ -1,46 +1,43 @@
-import type { Category, Post, User } from "@prisma/client";
+import type { Post, User } from "@prisma/client";
 import { prisma } from "~/db.server";
-import { setDefaultIdentity } from "~/lib/__mocks__/iap";
+import { setDefaultTestIdentity, setTestIdentity } from "~/lib/__mocks__/iap";
+import { expectRequiresUser } from "~/lib/test/expects";
+import * as Fixtures from "~/lib/test/fixtures";
+
 import { action } from "./reactions";
 
 const THUMBSUP = "👍";
 const HEART = "❤️";
 
-describe("post reactions action", () => {
+describe("POST /api/posts/$postId/reactions", () => {
   let author: User;
-  let category: Category;
   let post: Post;
 
   beforeEach(async () => {
-    author = await prisma.user.create({
-      data: {
-        email: "foo@example.com",
-      },
-    });
-    category = await prisma.category.create({
-      data: {
-        name: "Foo Category",
-        slug: "foo-category",
-      },
-    });
-    post = await prisma.post.create({
-      data: {
-        title: "Test",
-        content: "**Content**",
-        deleted: false,
-        published: true,
-        authorId: author.id,
-        categoryId: category.id,
-      },
+    author = await Fixtures.User();
+    post = await Fixtures.Post({
+      authorId: author.id,
     });
   });
 
   beforeEach(() => {
-    setDefaultIdentity();
+    setDefaultTestIdentity();
   });
 
-  afterEach(() => {
-    vi.restoreAllMocks();
+  it("requires user", async () => {
+    setTestIdentity(null);
+    await expectRequiresUser(
+      action({
+        request: new Request(
+          `http://localhost/api/posts/${post.id}/reactions`,
+          {
+            method: "POST",
+          }
+        ),
+        params: { postId: post.id },
+        context: {},
+      })
+    );
   });
 
   it("creates a new reaction", async () => {

--- a/app/routes/api/posts/$postId/reactions.test.ts
+++ b/app/routes/api/posts/$postId/reactions.test.ts
@@ -1,5 +1,6 @@
 import type { Category, Post, User } from "@prisma/client";
 import { prisma } from "~/db.server";
+import { setDefaultIdentity } from "~/lib/__mocks__/iap";
 import { action } from "./reactions";
 
 const THUMBSUP = "👍";
@@ -34,12 +35,19 @@ describe("post reactions action", () => {
     });
   });
 
+  beforeEach(() => {
+    setDefaultIdentity();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("creates a new reaction", async () => {
     const response: Response = await action({
       request: new Request(`http://localhost/api/posts/${post.id}/reactions`, {
         method: "POST",
         body: JSON.stringify({ emoji: HEART }),
-        headers: {},
       }),
       params: { postId: post.id },
       context: {},

--- a/app/routes/api/posts/$postId/subscription.test.ts
+++ b/app/routes/api/posts/$postId/subscription.test.ts
@@ -1,0 +1,38 @@
+import type { Post, User } from "@prisma/client";
+import { setDefaultTestIdentity, setTestIdentity } from "~/lib/__mocks__/iap";
+import { expectRequiresUser } from "~/lib/test/expects";
+import * as Fixtures from "~/lib/test/fixtures";
+
+import { action } from "./reactions";
+
+describe("POST /api/posts/$postId/subscription", () => {
+  let author: User;
+  let post: Post;
+
+  beforeEach(async () => {
+    author = await Fixtures.User();
+    post = await Fixtures.Post({
+      authorId: author.id,
+    });
+  });
+
+  beforeEach(() => {
+    setDefaultTestIdentity();
+  });
+
+  it("requires user", async () => {
+    setTestIdentity(null);
+    await expectRequiresUser(
+      action({
+        request: new Request(
+          `http://localhost/api/posts/${post.id}/subscription`,
+          {
+            method: "POST",
+          }
+        ),
+        params: { postId: post.id },
+        context: {},
+      })
+    );
+  });
+});

--- a/app/routes/c/$categorySlug.test.ts
+++ b/app/routes/c/$categorySlug.test.ts
@@ -1,0 +1,18 @@
+import { expectRequiresUser } from "~/lib/test/expects";
+import * as Fixtures from "~/lib/test/fixtures";
+import { loader } from "./$categorySlug";
+
+describe("GET /c/$categorySlug", () => {
+  it("requires user", async () => {
+    const category = await Fixtures.Category();
+    await expectRequiresUser(
+      loader({
+        request: new Request(`http://localhost/c/${category.slug}`, {
+          method: "GET",
+        }),
+        params: { categorySlug: category.slug },
+        context: {},
+      })
+    );
+  });
+});

--- a/app/routes/drafts.test.ts
+++ b/app/routes/drafts.test.ts
@@ -1,0 +1,16 @@
+import { expectRequiresUser } from "~/lib/test/expects";
+import { loader } from "./drafts";
+
+describe("GET /drafts", () => {
+  it("requires user", async () => {
+    await expectRequiresUser(
+      loader({
+        request: new Request(`http://localhost/drafts`, {
+          method: "GET",
+        }),
+        params: {},
+        context: {},
+      })
+    );
+  });
+});

--- a/app/routes/feeds/$feedId[.]xml.test.ts
+++ b/app/routes/feeds/$feedId[.]xml.test.ts
@@ -1,0 +1,20 @@
+import * as Fixtures from "~/lib/test/fixtures";
+import { loader } from "./$feedId[.]xml";
+
+describe("GET /feeds/$feedId.xml", () => {
+  it("renders xml", async () => {
+    const feed = await Fixtures.Feed();
+    const response = await loader({
+      request: new Request(`http://localhost/feeds/${feed.id}.xml`, {
+        method: "GET",
+        headers: {
+          host: "localhost",
+        },
+      }),
+      params: { feedId: feed.id },
+      context: {},
+    });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("application/xml");
+  });
+});

--- a/app/routes/feeds/$feedId[.]xml.tsx
+++ b/app/routes/feeds/$feedId[.]xml.tsx
@@ -1,7 +1,6 @@
 import type { LoaderFunction } from "@remix-run/node";
 import { getFeed } from "~/models/feed.server";
 import { getPostList } from "~/models/post.server";
-import { requireUserId } from "~/session.server";
 import { getPostLink } from "~/components/post-link";
 import invariant from "tiny-invariant";
 import { marked } from "marked";
@@ -11,13 +10,10 @@ import { buildUrl } from "~/lib/http";
 
 export const loader: LoaderFunction = async ({ request, params }) => {
   invariant(params.feedId, "feedId not found");
-  const userId = await requireUserId(request);
-
   const feed = await getFeed({ id: params.feedId });
   if (!feed) throw new Response("Not Found", { status: 404 });
 
   const posts = await getPostList({
-    userId,
     published: true,
     feedId: params.feedId,
   });

--- a/app/routes/image-uploads/$.tsx
+++ b/app/routes/image-uploads/$.tsx
@@ -4,14 +4,11 @@ import { Response, redirect } from "@remix-run/node";
 import type { LoaderFunction } from "@remix-run/node";
 import invariant from "tiny-invariant";
 
-import { requireUserId } from "~/session.server";
 import path from "path";
 
 const MAX_AGE = 60 * 60 ** 24;
 
-export const loader: LoaderFunction = async ({ request, params }) => {
-  await requireUserId(request);
-
+export const loader: LoaderFunction = async ({ params }) => {
   const fileParam = params["*"];
 
   invariant(fileParam, "filename is required");

--- a/app/routes/index.test.ts
+++ b/app/routes/index.test.ts
@@ -1,0 +1,16 @@
+import { expectRequiresUser } from "~/lib/test/expects";
+import { loader } from "./";
+
+describe("GET /", () => {
+  it("requires user", async () => {
+    await expectRequiresUser(
+      loader({
+        request: new Request(`http://localhost/`, {
+          method: "GET",
+        }),
+        params: {},
+        context: {},
+      })
+    );
+  });
+});

--- a/app/routes/new-post.test.ts
+++ b/app/routes/new-post.test.ts
@@ -1,0 +1,30 @@
+import { expectRequiresUser } from "~/lib/test/expects";
+import { action, loader } from "./new-post";
+
+describe("GET /new-post", () => {
+  it("requires user", async () => {
+    await expectRequiresUser(
+      loader({
+        request: new Request(`http://localhost/new-post`, {
+          method: "GET",
+        }),
+        params: {},
+        context: {},
+      })
+    );
+  });
+});
+
+describe("POST /new-post", () => {
+  it("requires user", async () => {
+    await expectRequiresUser(
+      action({
+        request: new Request(`http://localhost/new-post`, {
+          method: "POST",
+        }),
+        params: {},
+        context: {},
+      })
+    );
+  });
+});

--- a/app/routes/p/$postId/edit.test.ts
+++ b/app/routes/p/$postId/edit.test.ts
@@ -1,0 +1,33 @@
+import { expectRequiresUser } from "~/lib/test/expects";
+import * as Fixtures from "~/lib/test/fixtures";
+import { loader, action } from ".";
+
+describe("GET /p/$postId/edit", () => {
+  it("requires user", async () => {
+    const post = await Fixtures.Post();
+    await expectRequiresUser(
+      loader({
+        request: new Request(`http://localhost/p/${post.id}/edit`, {
+          method: "GET",
+        }),
+        params: { postId: post.id },
+        context: {},
+      })
+    );
+  });
+});
+
+describe("POST /p/$postId/edit", () => {
+  it("requires user", async () => {
+    const post = await Fixtures.Post();
+    await expectRequiresUser(
+      action({
+        request: new Request(`http://localhost/p/${post.id}/edit`, {
+          method: "POST",
+        }),
+        params: { postId: post.id },
+        context: {},
+      })
+    );
+  });
+});

--- a/app/routes/p/$postId/edit.test.ts
+++ b/app/routes/p/$postId/edit.test.ts
@@ -1,12 +1,10 @@
 import { expectRequiresUser } from "~/lib/test/expects";
 import * as Fixtures from "~/lib/test/fixtures";
-import { setTestIdentity } from "~/lib/__mocks__/iap";
 import { loader, action } from ".";
 
 describe("GET /p/$postId/edit", () => {
   it("requires user", async () => {
     const post = await Fixtures.Post();
-
     await expectRequiresUser(
       loader({
         request: new Request(`http://localhost/p/${post.id}/edit`, {
@@ -22,7 +20,6 @@ describe("GET /p/$postId/edit", () => {
 describe("POST /p/$postId/edit", () => {
   it("requires user", async () => {
     const post = await Fixtures.Post();
-
     await expectRequiresUser(
       action({
         request: new Request(`http://localhost/p/${post.id}/edit`, {

--- a/app/routes/p/$postId/edit.test.ts
+++ b/app/routes/p/$postId/edit.test.ts
@@ -1,10 +1,12 @@
 import { expectRequiresUser } from "~/lib/test/expects";
 import * as Fixtures from "~/lib/test/fixtures";
+import { setTestIdentity } from "~/lib/__mocks__/iap";
 import { loader, action } from ".";
 
 describe("GET /p/$postId/edit", () => {
   it("requires user", async () => {
     const post = await Fixtures.Post();
+
     await expectRequiresUser(
       loader({
         request: new Request(`http://localhost/p/${post.id}/edit`, {
@@ -20,6 +22,7 @@ describe("GET /p/$postId/edit", () => {
 describe("POST /p/$postId/edit", () => {
   it("requires user", async () => {
     const post = await Fixtures.Post();
+
     await expectRequiresUser(
       action({
         request: new Request(`http://localhost/p/${post.id}/edit`, {

--- a/app/routes/p/$postId/index.test.ts
+++ b/app/routes/p/$postId/index.test.ts
@@ -1,0 +1,33 @@
+import { expectRequiresUser } from "~/lib/test/expects";
+import * as Fixtures from "~/lib/test/fixtures";
+import { loader, action } from ".";
+
+describe("GET /p/$postId", () => {
+  it("requires user", async () => {
+    const post = await Fixtures.Post();
+    await expectRequiresUser(
+      loader({
+        request: new Request(`http://localhost/p/${post.id}`, {
+          method: "GET",
+        }),
+        params: { postId: post.id },
+        context: {},
+      })
+    );
+  });
+});
+
+describe("POST /p/$postId", () => {
+  it("requires user", async () => {
+    const post = await Fixtures.Post();
+    await expectRequiresUser(
+      action({
+        request: new Request(`http://localhost/p/${post.id}`, {
+          method: "POST",
+        }),
+        params: { postId: post.id },
+        context: {},
+      })
+    );
+  });
+});

--- a/app/routes/p/$postId/index.tsx
+++ b/app/routes/p/$postId/index.tsx
@@ -6,7 +6,7 @@ import invariant from "tiny-invariant";
 import { announcePost, getPost, updatePost } from "~/models/post.server";
 import { getReactionsForPosts } from "~/models/post-reactions.server";
 import type { PostQueryType } from "~/models/post.server";
-import { getCommentList, createComment } from "~/models/post-comments.server";
+import { getCommentList } from "~/models/post-comments.server";
 import type { User } from "~/models/user.server";
 import { requireUser, requireUserId } from "~/session.server";
 import { default as PostTemplate } from "~/components/post";
@@ -24,7 +24,6 @@ type LoaderData = {
 
 export const loader: LoaderFunction = async ({ request, params }) => {
   const user = await requireUser(request);
-  invariant(params.postId, "postId not found");
 
   const post = await getPost({ userId: user.id, id: params.postId });
   if (!post) {

--- a/app/routes/search.test.ts
+++ b/app/routes/search.test.ts
@@ -1,0 +1,16 @@
+import { expectRequiresUser } from "~/lib/test/expects";
+import { loader } from "./search";
+
+describe("GET /search", () => {
+  it("requires user", async () => {
+    await expectRequiresUser(
+      loader({
+        request: new Request(`http://localhost/search`, {
+          method: "GET",
+        }),
+        params: {},
+        context: {},
+      })
+    );
+  });
+});

--- a/app/routes/search.tsx
+++ b/app/routes/search.tsx
@@ -26,7 +26,7 @@ export const loader: LoaderFunction = async ({ request }) => {
   return json<LoaderData>({ postListPaginated, query });
 };
 
-export default function Index() {
+export default function Search() {
   const { postListPaginated, query } = useLoaderData() as LoaderData;
 
   return (

--- a/app/routes/settings.test.ts
+++ b/app/routes/settings.test.ts
@@ -1,0 +1,30 @@
+import { expectRequiresUser } from "~/lib/test/expects";
+import { action, loader } from "./settings";
+
+describe("GET /settings", () => {
+  it("requires user", async () => {
+    await expectRequiresUser(
+      loader({
+        request: new Request(`http://localhost/settings`, {
+          method: "GET",
+        }),
+        params: {},
+        context: {},
+      })
+    );
+  });
+});
+
+describe("POST /settings", () => {
+  it("requires user", async () => {
+    await expectRequiresUser(
+      action({
+        request: new Request(`http://localhost/settings`, {
+          method: "POST",
+        }),
+        params: {},
+        context: {},
+      })
+    );
+  });
+});

--- a/app/routes/u/$userEmail.test.ts
+++ b/app/routes/u/$userEmail.test.ts
@@ -1,0 +1,18 @@
+import { expectRequiresUser } from "~/lib/test/expects";
+import * as Fixtures from "~/lib/test/fixtures";
+import { loader } from "./$userEmail";
+
+describe("GET /u/$userEmail", () => {
+  it("requires user", async () => {
+    const user = await Fixtures.User();
+    await expectRequiresUser(
+      loader({
+        request: new Request(`http://localhost/u/${user.email}`, {
+          method: "GET",
+        }),
+        params: { userEmail: user.email },
+        context: {},
+      })
+    );
+  });
+});

--- a/app/routes/upload-image.test.ts
+++ b/app/routes/upload-image.test.ts
@@ -1,0 +1,16 @@
+import { expectRequiresUser } from "~/lib/test/expects";
+import { action } from "./upload-image";
+
+describe("POST /upload-image", () => {
+  it("requires user", async () => {
+    await expectRequiresUser(
+      action({
+        request: new Request(`http://localhost/upload-image`, {
+          method: "POST",
+        }),
+        params: {},
+        context: {},
+      })
+    );
+  });
+});

--- a/app/routes/welcome.test.ts
+++ b/app/routes/welcome.test.ts
@@ -1,0 +1,30 @@
+import { expectRequiresUser } from "~/lib/test/expects";
+import { action, loader } from "./welcome";
+
+describe("GET /welcome", () => {
+  it("requires user", async () => {
+    await expectRequiresUser(
+      loader({
+        request: new Request(`http://localhost/welcome`, {
+          method: "GET",
+        }),
+        params: {},
+        context: {},
+      })
+    );
+  });
+});
+
+describe("POST /welcome", () => {
+  it("requires user", async () => {
+    await expectRequiresUser(
+      action({
+        request: new Request(`http://localhost/welcome`, {
+          method: "POST",
+        }),
+        params: {},
+        context: {},
+      })
+    );
+  });
+});

--- a/app/session.server.ts
+++ b/app/session.server.ts
@@ -29,6 +29,7 @@ export async function getSession(request: Request) {
   if (request.hasOwnProperty("session")) {
     return request.session;
   }
+
   const identity = await getIdentity(request);
   const cookie = request.headers.get("Cookie");
   const session = await sessionStorage.getSession(cookie);

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,7 +83,7 @@
         "tailwindcss": "^3.0.23",
         "vite": "^2.9.1",
         "vite-tsconfig-paths": "^3.4.1",
-        "vitest": "^0.8.2"
+        "vitest": "^0.8.5"
       },
       "engines": {
         "node": ">=16.11"

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "tailwindcss": "^3.0.23",
     "vite": "^2.9.1",
     "vite-tsconfig-paths": "^3.4.1",
-    "vitest": "^0.8.2"
+    "vitest": "^0.8.5"
   },
   "engines": {
     "node": ">=16.11"

--- a/test/setup-test-env.ts
+++ b/test/setup-test-env.ts
@@ -11,17 +11,14 @@ const clearDatabase = async () => {
   const tablenames = await prisma.$queryRaw<
     Array<{ tablename: string }>
   >`SELECT tablename FROM pg_tables WHERE schemaname='public'`;
-
-  for (const { tablename } of tablenames) {
-    if (tablename !== "_prisma_migrations") {
-      try {
-        await prisma.$executeRawUnsafe(
-          `TRUNCATE TABLE "public"."${tablename}" CASCADE;`
-        );
-      } catch (error) {
-        console.log({ error });
-      }
-    }
+  const tableNames = tablenames
+    .filter(({ tablename }) => tablename !== "_prisma_migrations")
+    .map(({ tablename }) => `"public"."${tablename}"`)
+    .join(", ");
+  try {
+    await prisma.$executeRawUnsafe(`TRUNCATE TABLE ${tableNames} CASCADE;`);
+  } catch (error) {
+    console.log({ error });
   }
   // await prisma.$transaction([
   //   prisma.postSubscription.deleteMany(),

--- a/test/setup-test-env.ts
+++ b/test/setup-test-env.ts
@@ -1,6 +1,7 @@
 import { installGlobals } from "@remix-run/node";
 import "@testing-library/jest-dom/extend-expect";
 import { prisma } from "~/db.server";
+import { DefaultIdentity, setTestIdentity } from "~/lib/__mocks__/iap";
 
 installGlobals();
 
@@ -38,8 +39,8 @@ const createDummyUser = async () => {
   return await prisma.user.create({
     data: {
       id: "cl6vih0pm16012nklaetl2tvze",
-      email: "jane.doe@example.com",
-      externalId: "dummy-iap-user",
+      email: DefaultIdentity.email,
+      externalId: DefaultIdentity.id,
     },
   });
 };
@@ -52,12 +53,16 @@ global.beforeEach(async () => {
   global.DefaultFixtures = {};
 
   global.DefaultFixtures.DUMMY_USER = await createDummyUser();
+
+  setTestIdentity(null);
 });
 
-// global.afterEach(async () => {
-//   await clearDatabase();
-// });
+global.afterEach(async () => {
+  vi.clearAllMocks();
+});
 
 global.afterAll(async () => {
   await prisma.$disconnect();
 });
+
+vi.mock("~/lib/iap");

--- a/test/setup-test-env.ts
+++ b/test/setup-test-env.ts
@@ -1,7 +1,7 @@
 import { installGlobals } from "@remix-run/node";
 import "@testing-library/jest-dom/extend-expect";
 import { prisma } from "~/db.server";
-import { DefaultIdentity, setTestIdentity } from "~/lib/__mocks__/iap";
+import { DefaultTestIdentity, setTestIdentity } from "~/lib/__mocks__/iap";
 
 installGlobals();
 
@@ -39,8 +39,8 @@ const createDummyUser = async () => {
   return await prisma.user.create({
     data: {
       id: "cl6vih0pm16012nklaetl2tvze",
-      email: DefaultIdentity.email,
-      externalId: DefaultIdentity.id,
+      email: DefaultTestIdentity.email,
+      externalId: DefaultTestIdentity.id,
     },
   });
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -9620,7 +9620,7 @@
   optionalDependencies:
     "fsevents" "~2.3.2"
 
-"vitest@^0.8.2":
+"vitest@^0.8.5":
   "integrity" "sha512-UOBAfyLUn9++isUDC5vk8joLcaBZj7esLS2Yx3GZSRMWzayOfEEzU1Iv4SBb4HkJun9e1D5ifZoSclhNHKn7IA=="
   "resolved" "https://registry.npmjs.org/vitest/-/vitest-0.8.5.tgz"
   "version" "0.8.5"


### PR DESCRIPTION
This adds support for full application-enforced authentication, with optional IAP headers. Some UX will not be great yet (e.g. the 401 page is useless).

It adds tests for all existing routes that require auth, as well as pages requiring admin.

Pages which are allowed without auth are:

- /about
- /feed/$feedId.xml
- /image-uploads/$

Contains a set of test utilities to easily assert on auth requirements, as well as helpers to mock identities.