### PR TITLE
Update email 'from' `Vanguard` > `Sentry Vanguard`

### DIFF
--- a/app/lib/email.ts
+++ b/app/lib/email.ts
@@ -84,7 +84,7 @@ export const notify = async ({
 
   try {
     await transport.sendMail({
-      from: `"Vanguard" <${process.env.SMTP_FROM}>`,
+      from: `"Sentry Vanguard" <${process.env.SMTP_FROM}>`,
       to: config.to,
       subject,
       replyTo: config.to,


### PR DESCRIPTION
Emails from Sentry's "Vanguard" app look eerily similar to emails coming from the Vanguard investment management company.

Updating the email sender "from" field to make this more explicit