### PR TITLE
Add blockquote style

### DIFF
--- a/app/styles/global.tsx
+++ b/app/styles/global.tsx
@@ -109,6 +109,11 @@ const GlobalStyles = createGlobalStyle`
     line-height: 1.6;
   }
 
+  blockquote {
+    padding-left: 1rem;
+    border-left: 1px solid ${(p) => p.theme.borderColor};
+  }
+
   ul ul,
   ul ol,
   ol ul


### PR DESCRIPTION
Blockquotes are currently unstyled, you can't tell which are which in [e.g. here](https://vanguard.getsentry.net/p/clhyn40ed000cs60lre4g6mwm):

<img width="640" alt="nerp derp" src="https://github.com/getsentry/vanguard/assets/134455/13979d79-46a6-452d-ac97-28d75cd8dce3">