### PR TITLE
Fixing publishedAt formatting

### DIFF
--- a/app/lib/slack.ts
+++ b/app/lib/slack.ts
@@ -3,6 +3,9 @@ import type { PostQueryType } from "~/models/post.server";
 import summarize from "./summarize";
 
 import dayjs from "dayjs";
+import advancedFormat from "dayjs/plugin/advancedFormat";
+
+dayjs.extend(advancedFormat);
 
 export type SlackConfig = {
   webhookUrl: string;


### PR DESCRIPTION
In order to use the `Do` date format with day.js, you have to use the [advancedFormat](https://day.js.org/docs/en/plugin/advanced-format#:~:text=Quarter-,Do,-1st%202nd%20...%2031st) plugin. Otherwise it doesn't format correctly.

