### PR TITLE
remove package-lock copy pnpm-lock.yaml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ FROM base as production-deps
 WORKDIR /app
 
 COPY --from=deps /app/node_modules ./node_modules
-ADD package.json package-lock.json ./
+ADD package.json pnpm-lock.yaml ./
 
 # XXX: some issues with using db seed which is considered dev, so give up on this optimization
 # RUN npm prune --production


### PR DESCRIPTION
this PR removed package-lock (because we use pnpm) so just copying that on the second phase build:

https://github.com/getsentry/vanguard/pull/128#issuecomment-1836952409

Not sure we need that just yolo'ing here