### PR TITLE
fix: Set correct directory for database migrations step to pick up node_modules

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -39,6 +39,7 @@ steps:
         docker build -f Dockerfile-proxy -t ${_IMAGE_NAME}-proxy .
   - id: "Run Database Migrations"
     name: "${_IMAGE_NAME}-proxy"
+    dir: /app
     env:
       - "DATABASE_NAME=${_DATABASE_NAME}"
       - "DATABASE_USER=${_DATABASE_USER}"


### PR DESCRIPTION
Last PR solved half of the problem, now it's Command "prisma" not found because node_modules are in a different directory.
