### PR TITLE
chore(notifications): add verbose tracing to announcePost flow

### DIFF
--- a/app/lib/email.ts
+++ b/app/lib/email.ts
@@ -30,11 +30,13 @@ let mailTransport: Transporter<SMTPTransport.SentMessageInfo>;
 // XXX(dcramer): futuer proof for optional email support
 const hasEmailSupport = () => {
   if (!process.env.BASE_URL) {
+    console.error("[email] hasEmailSupport=false — BASE_URL is not configured");
     error("BASE_URL is not configured");
     return false;
   }
 
   if (!process.env.SMTP_FROM) {
+    console.error("[email] hasEmailSupport=false — SMTP_FROM is not configured");
     error("SMTP_FROM is not configured");
     return false;
   }
@@ -68,9 +70,16 @@ export const notify = async ({
   config: EmailConfig;
   transport?: Transporter<SMTPTransport.SentMessageInfo>;
 }) => {
-  if (!hasEmailSupport()) return;
+  if (!hasEmailSupport()) {
+    console.error(
+      `[email.notify] aborted — hasEmailSupport returned false (post ${post.id} to ${config.to})`,
+    );
+    return;
+  }
 
-  console.log(`Sending email notification for post ${post.id} to ${config.to}`);
+  console.log(
+    `[email.notify] start — post=${post.id} to=${config.to} smtpHost=${process.env.SMTP_HOST ?? "<unset>"}`,
+  );
 
   if (!transport) {
     if (!mailTransport) mailTransport = createMailTransport();
@@ -92,7 +101,12 @@ export const notify = async ({
       text: `View this post on Vanguard: ${postUrl}\n\n${post.content}`,
       html: buildPostEmail(post),
     });
-  } catch {
+    console.log(`[email.notify] success — post=${post.id} to=${config.to}`);
+  } catch (err) {
+    console.error(
+      `[email.notify] sendMail threw — post=${post.id} to=${config.to}`,
+      err instanceof Error ? err.message : err,
+    );
     error("email notification failed");
   }
 };

--- a/app/lib/slack.ts
+++ b/app/lib/slack.ts
@@ -16,10 +16,19 @@ export type SlackConfig = {
 
 export const notify = async ({ post, config }: { post: PostQueryType; config: SlackConfig }) => {
   const { author, category } = post;
-  console.log(`Sending Slack notification for post ${post.id}`);
+  console.log(
+    `[slack.notify] start — post=${post.id} category=${category.name} webhookHost=${(() => {
+      try {
+        return new URL(config.webhookUrl).host;
+      } catch {
+        return "<invalid-url>";
+      }
+    })()}`,
+  );
 
   if (!process.env.BASE_URL) {
     error("BASE_URL is not configured");
+    console.error(`[slack.notify] aborting — BASE_URL is not configured (post ${post.id})`);
     return;
   }
 
@@ -76,9 +85,15 @@ export const notify = async ({ post, config }: { post: PostQueryType; config: Sl
     } catch {
       data = res.body;
     }
+    console.error(
+      `[slack.notify] webhook returned non-200 — post=${post.id} status=${res.status}`,
+      data,
+    );
     error("slack webhook failed", {
       context: { webhook: data },
       tags: { statusCode: res.status },
     });
+  } else {
+    console.log(`[slack.notify] success — post=${post.id} status=${res.status}`);
   }
 };

--- a/app/lib/wait-until.ts
+++ b/app/lib/wait-until.ts
@@ -3,8 +3,13 @@ import { waitUntil as vercelWaitUntil } from "@vercel/functions";
 export function waitUntil(promise: Promise<unknown>): void {
   try {
     vercelWaitUntil(promise);
-  } catch {
+    console.log("[waitUntil] handed promise to @vercel/functions waitUntil");
+  } catch (err) {
     // Local dev / non-Vercel environment — just let it run
-    promise.catch((err) => console.error("waitUntil background error:", err));
+    console.log(
+      "[waitUntil] @vercel/functions waitUntil threw — falling back to fire-and-forget",
+      err instanceof Error ? err.message : String(err),
+    );
+    promise.catch((bgErr) => console.error("[waitUntil] background error:", bgErr));
   }
 }

--- a/app/models/post.server.ts
+++ b/app/models/post.server.ts
@@ -50,6 +50,13 @@ const PUBLIC_FEED_COLUMNS = {
 } as const;
 
 export function announcePost(post: PostQueryType): void {
+  // Verbose logging while we debug a production miss where notifications
+  // didn't fan out. Every line is prefixed `[announcePost]` so it's easy to
+  // grep in `vercel logs --since=…`. Remove once root-caused.
+  console.log(
+    `[announcePost] entry — post=${post.id} category=${post.categoryId} VERCEL_ENV=${process.env.VERCEL_ENV ?? "<unset>"} BASE_URL=${process.env.BASE_URL ?? "<unset>"} SMTP_FROM=${process.env.SMTP_FROM ? "set" : "<unset>"} SLACK_WEBHOOK_URL=${process.env.SLACK_WEBHOOK_URL ? "set" : "<unset>"}`,
+  );
+
   // On Vercel, fan-out notifications fire ONLY in production. Preview /
   // development deployments could be pointed at a Neon branch with real
   // per-category webhook + email rows (especially after Todo 14's data
@@ -63,24 +70,54 @@ export function announcePost(post: PostQueryType): void {
     return;
   }
 
+  console.log(`[announcePost] gate passed — scheduling waitUntil for post ${post.id}`);
+
   waitUntil(
     (async () => {
-      const emailConfig = await db.query.categoryEmails.findMany({
-        where: eq(categoryEmails.categoryId, post.categoryId),
-      });
-      await Promise.all(
-        emailConfig.map((config) => email.notify({ post, config: config as email.EmailConfig })),
-      );
+      console.log(`[announcePost] waitUntil started — post ${post.id}`);
+      try {
+        const emailConfig = await db.query.categoryEmails.findMany({
+          where: eq(categoryEmails.categoryId, post.categoryId),
+        });
+        console.log(
+          `[announcePost] categoryEmails lookup — post=${post.id} category=${post.categoryId} count=${emailConfig.length}`,
+        );
+        await Promise.all(
+          emailConfig.map((config) => email.notify({ post, config: config as email.EmailConfig })),
+        );
 
-      let slackConfig: slack.SlackConfig[] = await db.query.categorySlacks.findMany({
-        where: eq(categorySlacks.categoryId, post.categoryId),
-      });
-      if (!slackConfig.length && process.env.SLACK_WEBHOOK_URL) {
-        slackConfig = [{ webhookUrl: process.env.SLACK_WEBHOOK_URL }];
+        let slackConfig: slack.SlackConfig[] = await db.query.categorySlacks.findMany({
+          where: eq(categorySlacks.categoryId, post.categoryId),
+        });
+        console.log(
+          `[announcePost] categorySlacks lookup — post=${post.id} category=${post.categoryId} count=${slackConfig.length}`,
+        );
+        if (!slackConfig.length && process.env.SLACK_WEBHOOK_URL) {
+          console.log(
+            `[announcePost] no per-category Slack rows — falling back to SLACK_WEBHOOK_URL env var`,
+          );
+          slackConfig = [{ webhookUrl: process.env.SLACK_WEBHOOK_URL }];
+        } else if (!slackConfig.length) {
+          console.log(
+            `[announcePost] no per-category Slack rows AND no SLACK_WEBHOOK_URL — Slack fanout will be a no-op`,
+          );
+        }
+        await Promise.all(
+          slackConfig.map((config) => slack.notify({ post, config: config as slack.SlackConfig })),
+        );
+        console.log(`[announcePost] waitUntil finished — post ${post.id}`);
+      } catch (err) {
+        // Don't log `err` directly: Undici's URL-parse errors include the full
+        // input URL in the message (e.g. `Failed to parse URL from
+        // https://hooks.slack.com/services/T.../B.../...`), and dumping the raw
+        // error object would leak the Slack webhook secret into Vercel logs.
+        // Scrub anything URL-shaped before logging.
+        const message = err instanceof Error ? err.message : String(err);
+        const safeMessage = message.replace(/https?:\/\/\S+/g, "<redacted-url>");
+        const name = err instanceof Error ? err.name : "unknown";
+        console.error(`[announcePost] waitUntil threw — post ${post.id} — ${name}: ${safeMessage}`);
+        throw err;
       }
-      await Promise.all(
-        slackConfig.map((config) => slack.notify({ post, config: config as slack.SlackConfig })),
-      );
     })(),
   );
 }

--- a/app/routes/new-post.tsx
+++ b/app/routes/new-post.tsx
@@ -26,9 +26,13 @@ export async function action({ request }: ActionFunctionArgs) {
   const title = formData.get("title");
   const content = formData.get("content");
   const categoryId = formData.get("categoryId");
-  const published =
-    formData.get("published") === "true" || formData.get("published") === "announce";
-  const announce = formData.get("published") === "announce";
+  const publishedValue = formData.get("published");
+  const published = publishedValue === "true" || publishedValue === "announce";
+  const announce = publishedValue === "announce";
+
+  console.log(
+    `[new-post action] publishedValue=${String(publishedValue)} → published=${published} announce=${announce}`,
+  );
   const feedIds = formData.get("feedId") ? (formData.getAll("feedId") as string[]) : null;
 
   if (typeof categoryId !== "string" || categoryId.length === 0) {
@@ -83,7 +87,12 @@ export async function action({ request }: ActionFunctionArgs) {
   });
 
   if (announce) {
+    console.log(`[new-post action] calling announcePost for ${post.id}`);
     await announcePost(post);
+  } else {
+    console.log(
+      `[new-post action] NOT calling announcePost — post=${post.id} announce=${announce}`,
+    );
   }
 
   await syndicatePost(post);

--- a/app/routes/p.$postId._index.tsx
+++ b/app/routes/p.$postId._index.tsx
@@ -50,20 +50,35 @@ export const action: ActionFunction = async ({ request, params }) => {
   invariant(params.postId, "postId not found");
 
   const formData = await request.formData();
-  const published =
-    formData.get("published") === "true" || formData.get("published") === "announce";
+  const publishedValue = formData.get("published");
+  const published = publishedValue === "true" || publishedValue === "announce";
+
+  console.log(
+    `[p.$postId action] postId=${params.postId} publishedValue=${String(publishedValue)} → published=${published}`,
+  );
 
   if (published) {
-    const announce = published && formData.get("published") === "announce";
+    const announce = publishedValue === "announce";
     const post = await updatePost({
       id: params.postId,
       user,
       published,
     });
 
+    console.log(
+      `[p.$postId action] updatePost done — post=${post.id} deleted=${post.deleted} announce=${announce}`,
+    );
+
     if (!post.deleted && announce) {
+      console.log(`[p.$postId action] calling announcePost for ${post.id}`);
       announcePost(post);
+    } else {
+      console.log(
+        `[p.$postId action] NOT calling announcePost — post=${post.id} deleted=${post.deleted} announce=${announce}`,
+      );
     }
+  } else {
+    console.log(`[p.$postId action] no publish flag set on form submission — doing nothing`);
   }
 
   return {};

--- a/app/routes/p.$postId_.edit.tsx
+++ b/app/routes/p.$postId_.edit.tsx
@@ -46,6 +46,10 @@ export async function action({ request, params }: ActionFunctionArgs) {
   const announce = published && formData.get("published") === "announce";
   const deleted = formData.get("deleted") !== null ? !!formData.get("deleted") : undefined;
 
+  console.log(
+    `[p.$postId_.edit action] postId=${params.postId} publishedValue=${String(formData.get("published"))} → published=${String(published)} announce=${announce} deleted=${String(deleted)}`,
+  );
+
   if (categoryId !== null && (typeof categoryId !== "string" || categoryId.length === 0)) {
     return Response.json({ errors: { categoryId: "Category is required" } }, { status: 400 });
   }
@@ -113,7 +117,12 @@ export async function action({ request, params }: ActionFunctionArgs) {
   });
 
   if (!post.deleted && announce) {
+    console.log(`[p.$postId_.edit action] calling announcePost for ${post.id}`);
     await announcePost(post);
+  } else {
+    console.log(
+      `[p.$postId_.edit action] NOT calling announcePost — post=${post.id} deleted=${post.deleted} announce=${announce}`,
+    );
   }
 
   await syndicatePost(post);


### PR DESCRIPTION
## Why

A user published a post in production and **neither the Slack notification nor the email fanout fired.** We had no log breadcrumbs to tell us why — `announcePost` runs inside `waitUntil` after the response is already sent, every error path in `app/lib/email.ts` and `app/lib/slack.ts` is silently swallowed or only surfaced to Sentry as a one-line message, and there was nothing in Vercel logs to tell us:

1. Did the action even take the announce branch? (or did the user click "Publish Silently"?)
2. Did `announcePost` enter and pass the `VERCEL_ENV === "production"` gate?
3. Did the DB lookups return rows? Did the `SLACK_WEBHOOK_URL` env-var fallback fire? Did `transport.sendMail` throw?

This branch adds **purely additive, greppable tracing** through every decision point so the next failure leaves enough evidence to root-cause without guessing.

> Spoiler: the issue turned out to be `BASE_URL` configured in the Vercel dashboard but left as an empty string — both `slack.notify` and `email.hasEmailSupport()` short-circuit on `!process.env.BASE_URL`. Empty string is falsy. That single missing var killed both channels simultaneously, which matches the Sentry alert `BASE_URL is not configured` exactly. Fix is operational (set `BASE_URL` properly in Vercel prod env), but the missing instrumentation is a real gap and worth landing regardless.

## What's logged

All lines are prefixed for easy `vercel logs --prod | grep` filtering:

- **`[new-post action]`, `[p.$postId action]`, `[p.$postId_.edit action]`** — which form value came in (`true` / `announce` / `false` / null), the derived `published` and `announce` booleans, and an explicit "calling announcePost" / "NOT calling announcePost" line with the reason.

- **`[announcePost]`** — entry banner with the full env signal (`VERCEL_ENV`, `BASE_URL`, presence of `SMTP_FROM` and `SLACK_WEBHOOK_URL` — values redacted to `set`/`<unset>`); whether the production gate passed; `waitUntil` start/finish; row counts from the `categoryEmails` and `categorySlacks` lookups; whether the `SLACK_WEBHOOK_URL` env-var fallback kicked in; and a try/catch around the whole fanout so a thrown promise inside `waitUntil` surfaces in Vercel logs instead of vanishing.

- **`[waitUntil]`** — confirms whether `@vercel/functions.waitUntil` accepted the promise or threw the local-dev fallback.

- **`[slack.notify]`** — start (with webhook **host**, never the full URL), success, and non-200 responses with the response body.

- **`[email.notify]`** — start (with destination + SMTP host), `hasEmailSupport` short-circuit reason if it bails, success, and the actual `sendMail` error message if it throws (previously swallowed by a bare `catch {}`).

## Security note

The `announcePost` `waitUntil` catch block intentionally does NOT log the raw error object. Undici's URL-parse errors include the full input URL in their message (`Failed to parse URL from https://hooks.slack.com/services/...`), so dumping `err` directly would leak the Slack webhook secret into Vercel logs. We extract `err.name` + `err.message` and scrub anything URL-shaped (`/https?:\/\/\S+/g` → `<redacted-url>`) before logging.

This was caught in code review and fixed before push — see commit body for details.

## Scope & lifetime

- **Purely additive.** No control-flow changes. `pnpm typecheck`, `vp lint`, and `pnpm test:vitest` (135/135) all green.
- **Marked temporary in source comments** — to be removed (or dialed back to debug-level) once we've root-caused the missed notification and confirmed the env-var fix in prod.

## Verification

- ✅ `pnpm typecheck`
- ✅ `vp lint`
- ✅ `pnpm test:vitest` (39 files / 135 tests)
- ✅ Reviewer pass (codex/gpt-5.4) — one P2 finding about webhook-URL leakage in error logging, addressed before push
