### PR TITLE
fix(email): inline private image-uploads as CID attachments

### DIFF
--- a/app/lib/email-images.ts
+++ b/app/lib/email-images.ts
@@ -1,0 +1,95 @@
+import os from "os";
+import fs from "fs/promises";
+import path from "path";
+import { get } from "@vercel/blob";
+import { EXT_TO_MIME } from "~/lib/upload-handler";
+
+const MAX_IMAGES = 10;
+const MAX_TOTAL_BYTES = 20 * 1024 * 1024; // 20 MB
+
+export type InlineAttachment = {
+  cid: string;
+  filename: string;
+  content: Buffer;
+  contentType: string;
+  contentDisposition: "inline";
+};
+
+export async function inlinePrivateImages(
+  html: string,
+): Promise<{ html: string; attachments: InlineAttachment[] }> {
+  const baseUrl = process.env.BASE_URL;
+  if (!baseUrl) return { html, attachments: [] };
+
+  const escapedBase = baseUrl.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const regex = new RegExp(`src="${escapedBase}/image-uploads/([^"]+)"`, "g");
+
+  const matches = [...html.matchAll(regex)];
+  if (matches.length === 0) return { html, attachments: [] };
+
+  // Dedupe by pathname
+  const pathnameToCid = new Map<string, string>();
+  let counter = 0;
+  for (const match of matches) {
+    const pathname = match[1];
+    if (!pathnameToCid.has(pathname)) {
+      pathnameToCid.set(pathname, `vg-img-${counter++}`);
+    }
+  }
+
+  const attachments: InlineAttachment[] = [];
+  let totalBytes = 0;
+  const fetchedPathnameMap = new Map<string, string>(); // pathname -> cid (only successfully fetched)
+
+  for (const [pathname, cid] of pathnameToCid) {
+    if (attachments.length >= MAX_IMAGES) {
+      console.warn(`[email-images] skipping ${pathname} — MAX_IMAGES (${MAX_IMAGES}) reached`);
+      continue;
+    }
+
+    try {
+      let content: Buffer;
+      let contentType: string;
+
+      if (process.env.BLOB_READ_WRITE_TOKEN) {
+        const { stream, headers } = await get(pathname, { access: "private" });
+        content = Buffer.from(await new Response(stream).arrayBuffer());
+        contentType = headers.get("content-type") ?? "application/octet-stream";
+      } else {
+        const filePath = path.join(os.tmpdir(), pathname);
+        content = await fs.readFile(filePath);
+        const ext = path.extname(pathname).slice(1).toLowerCase();
+        contentType = EXT_TO_MIME[ext] || "application/octet-stream";
+      }
+
+      if (totalBytes + content.length > MAX_TOTAL_BYTES) {
+        console.warn(`[email-images] skipping ${pathname} — MAX_TOTAL_BYTES limit reached`);
+        continue;
+      }
+
+      totalBytes += content.length;
+      attachments.push({
+        cid,
+        filename: path.basename(pathname),
+        content,
+        contentType,
+        contentDisposition: "inline",
+      });
+      fetchedPathnameMap.set(pathname, cid);
+    } catch (err) {
+      console.warn(
+        `[email-images] skipping ${pathname} — fetch failed: ${err instanceof Error ? err.message : err}`,
+      );
+    }
+  }
+
+  // Replace src URLs for successfully fetched images
+  let rewrittenHtml = html;
+  for (const [pathname, cid] of fetchedPathnameMap) {
+    const escapedPathname = pathname.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const srcRegex = new RegExp(`src="${escapedBase}/image-uploads/${escapedPathname}"`, "g");
+    rewrittenHtml = rewrittenHtml.replace(srcRegex, `src="cid:${cid}"`);
+  }
+
+  return { html: rewrittenHtml, attachments };
+}

--- a/app/lib/email.test.ts
+++ b/app/lib/email.test.ts
@@ -1,4 +1,7 @@
 // @ts-nocheck
+import os from "os";
+import fs from "fs/promises";
+import path from "path";
 import type { Transporter } from "nodemailer";
 import { createTransport } from "nodemailer";
 import type Mail from "nodemailer/lib/mailer";
@@ -12,6 +15,18 @@ import type { PostComment } from "~/models/post-comments.server";
 import type { User } from "~/models/user.server";
 
 import { notify, notifyComment } from "./email";
+
+const PNG_1x1 = Buffer.from(
+  "89504E470D0A1A0A0000000D49484452000000010000000108060000001F15C4890000000D49444154789C6300010000000500010D0A2DB40000000049454E44AE426082",
+  "hex",
+);
+
+const writeTmpFile = async (pathname: string, bytes: Buffer) => {
+  const fp = path.join(os.tmpdir(), pathname);
+  await fs.mkdir(path.dirname(fp), { recursive: true });
+  await fs.writeFile(fp, bytes);
+  return fp;
+};
 
 let transport: Transporter<SMTPTransport.SentMessageInfo>;
 let outbox: Mail.Options[];
@@ -192,5 +207,143 @@ describe("notifyComment", () => {
       expect(msg.to).toBe(author.email);
       expect(msg.subject).toBe("Re: An Essay");
     });
+  });
+});
+
+describe("notify with images", () => {
+  let author: User;
+  let post: Post;
+
+  beforeEach(async () => {
+    author = await Fixtures.User({
+      name: "Joe Doe",
+      email: "joe@example.com",
+    });
+  });
+
+  test("single uploaded image is inlined as CID attachment", async () => {
+    await writeTmpFile("test/foo.png", PNG_1x1);
+    post = await Fixtures.Post({
+      content: "![alt](/image-uploads/test/foo.png)",
+      authorId: author.id,
+    });
+    await notify({ post, config: { to: "test@example.com" }, transport });
+    expect(outbox.length).toBe(1);
+    const msg = outbox[0];
+    expect(msg.attachments).toHaveLength(1);
+    const att = msg.attachments[0];
+    expect(msg.html).toContain(`src="cid:${att.cid}"`);
+    expect(msg.html).not.toContain("/image-uploads/test/foo.png");
+    expect(att.contentType).toBe("image/png");
+    expect(att.contentDisposition).toBe("inline");
+  });
+
+  test("two distinct uploaded images produce 2 attachments with distinct CIDs", async () => {
+    await writeTmpFile("test/img1.png", PNG_1x1);
+    await writeTmpFile("test/img2.png", PNG_1x1);
+    post = await Fixtures.Post({
+      content: "![a](/image-uploads/test/img1.png) ![b](/image-uploads/test/img2.png)",
+      authorId: author.id,
+    });
+    await notify({ post, config: { to: "test@example.com" }, transport });
+    expect(outbox.length).toBe(1);
+    const msg = outbox[0];
+    expect(msg.attachments).toHaveLength(2);
+    const cids = msg.attachments.map((a) => a.cid);
+    expect(cids[0]).not.toBe(cids[1]);
+  });
+
+  test("same image referenced twice produces 1 attachment and both tags share the CID", async () => {
+    await writeTmpFile("test/shared.png", PNG_1x1);
+    post = await Fixtures.Post({
+      content: "![a](/image-uploads/test/shared.png) and ![b](/image-uploads/test/shared.png)",
+      authorId: author.id,
+    });
+    await notify({ post, config: { to: "test@example.com" }, transport });
+    expect(outbox.length).toBe(1);
+    const msg = outbox[0];
+    expect(msg.attachments).toHaveLength(1);
+    const cid = msg.attachments[0].cid;
+    const matches = [...msg.html.matchAll(new RegExp(`cid:${cid}`, "g"))];
+    expect(matches.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test("external image is left untouched with no attachment", async () => {
+    post = await Fixtures.Post({
+      content: "![ext](https://example.com/x.png)",
+      authorId: author.id,
+    });
+    await notify({ post, config: { to: "test@example.com" }, transport });
+    expect(outbox.length).toBe(1);
+    const msg = outbox[0];
+    expect(msg.attachments ?? []).toHaveLength(0);
+    expect(msg.html).toContain("https://example.com/x.png");
+  });
+
+  test("missing tmp file fails soft — no attachment, src untouched, no throw", async () => {
+    post = await Fixtures.Post({
+      content: "![missing](/image-uploads/test/missing.png)",
+      authorId: author.id,
+    });
+    await notify({ post, config: { to: "test@example.com" }, transport });
+    expect(outbox.length).toBe(1);
+    const msg = outbox[0];
+    expect(msg.attachments ?? []).toHaveLength(0);
+    expect(msg.html).toContain("/image-uploads/test/missing.png");
+  });
+
+  test("custom avatar (/image-uploads/...) is inlined as CID attachment", async () => {
+    await writeTmpFile("test/avatar.png", PNG_1x1);
+    const authorWithAvatar = await Fixtures.User({
+      picture: "/image-uploads/test/avatar.png",
+    });
+    post = await Fixtures.Post({
+      content: "Hello world",
+      authorId: authorWithAvatar.id,
+    });
+    await notify({ post, config: { to: "test@example.com" }, transport });
+    expect(outbox.length).toBe(1);
+    const msg = outbox[0];
+    expect(msg.attachments).toHaveLength(1);
+    const att = msg.attachments[0];
+    expect(msg.html).toContain(`src="cid:${att.cid}"`);
+    expect(msg.html).not.toContain("/image-uploads/test/avatar.png");
+  });
+
+  test("Google CDN avatar renders with bare URL, no BASE_URL prefix, no attachment", async () => {
+    const googleAuthor = await Fixtures.User({
+      picture: "https://lh3.googleusercontent.com/abc",
+    });
+    post = await Fixtures.Post({
+      content: "Hello world",
+      authorId: googleAuthor.id,
+    });
+    await notify({ post, config: { to: "test@example.com" }, transport });
+    expect(outbox.length).toBe(1);
+    const msg = outbox[0];
+    expect(msg.attachments ?? []).toHaveLength(0);
+    expect(msg.html).toContain('src="https://lh3.googleusercontent.com/abc"');
+    expect(msg.html).not.toContain("http://localhosthttps://");
+  });
+
+  test("notifyComment with /image-uploads/ author picture inlines the avatar", async () => {
+    await writeTmpFile("test/comment-avatar.png", PNG_1x1);
+    const commentAuthor = await Fixtures.User({
+      picture: "/image-uploads/test/comment-avatar.png",
+    });
+    const subscriber = await Fixtures.User();
+    post = await Fixtures.Post({ authorId: author.id });
+    const comment = await Fixtures.PostComment({
+      authorId: commentAuthor.id,
+    });
+    comment.author = commentAuthor;
+    await db.insert(postSubscriptions).values({ userId: subscriber.id, postId: post.id });
+    await notifyComment({ post, comment, config: { to: "test@example.com" }, transport });
+    expect(outbox.length).toBe(1);
+    const msg = outbox[0];
+    expect(msg.attachments).toHaveLength(1);
+    const att = msg.attachments[0];
+    expect(msg.html).toContain(`src="cid:${att.cid}"`);
+    expect(msg.html).not.toContain("/image-uploads/test/comment-avatar.png");
   });
 });

--- a/app/lib/email.ts
+++ b/app/lib/email.ts
@@ -7,6 +7,7 @@ import type { PostQueryType } from "~/models/post.server";
 import type { PostCommentWithAuthor } from "~/models/post-comments.server";
 import { getSubscriptions } from "~/models/post-subscription.server";
 import summarize from "./summarize";
+import { inlinePrivateImages } from "./email-images";
 import { lightTheme } from "~/styles/theme";
 import { escapeHtml } from "./html";
 import { getUserById } from "~/models/user.server";
@@ -91,6 +92,8 @@ export const notify = async ({
   const subject = config.subjectPrefix ? `${config.subjectPrefix} ${post.title}` : post.title;
 
   try {
+    const rawHtml = buildPostEmail(post);
+    const { html, attachments } = await inlinePrivateImages(rawHtml);
     await transport.sendMail({
       from: `"Sentry Vanguard" <${process.env.SMTP_FROM}>`,
       to: config.to,
@@ -99,7 +102,8 @@ export const notify = async ({
       cc: [sender],
       sender,
       text: `View this post on Vanguard: ${postUrl}\n\n${post.content}`,
-      html: buildPostEmail(post),
+      html,
+      attachments,
     });
     console.log(`[email.notify] success — post=${post.id} to=${config.to}`);
   } catch (err) {
@@ -109,6 +113,12 @@ export const notify = async ({
     );
     error("email notification failed");
   }
+};
+
+const resolveAvatarUrl = (picture: string | null | undefined): string => {
+  if (!picture) return `${process.env.BASE_URL}/img/placeholder-avatar.png`;
+  if (picture.startsWith("http://") || picture.startsWith("https://")) return picture;
+  return `${process.env.BASE_URL}${picture}`;
 };
 
 const buildPostEmail = (post: PostQueryType): string => {
@@ -125,9 +135,7 @@ const buildPostEmail = (post: PostQueryType): string => {
     };">${escapeHtml(post.title)}</h2>
     <table cellpadding="0" cellspacing="0" border="0">
         <tr>
-          <td style="vertical-align:top"><img src="${process.env.BASE_URL}${
-            post.author.picture || `/img/placeholder-avatar.png`
-          }" width="36" height="36" style="border-radius:36px;display:block;" /></td>
+          <td style="vertical-align:top"><img src="${resolveAvatarUrl(post.author.picture)}" width="36" height="36" style="border-radius:36px;display:block;" /></td>
         <td style="padding-left:15px">
         <table cellpadding="0" cellspacing="0" border="0">
           <tr>
@@ -179,27 +187,32 @@ export const notifyComment = async ({
     }
   }
 
-  subscriptions
-    .filter((user) => user.id !== comment.authorId)
-    .forEach(async (user) => {
-      console.log(`Sending email notification for comment ${comment.id} to ${user.email}`);
+  await Promise.all(
+    subscriptions
+      .filter((user) => user.id !== comment.authorId)
+      .map(async (user) => {
+        console.log(`Sending email notification for comment ${comment.id} to ${user.email}`);
 
-      const html = buildCommentHtml(user, post, comment, parent);
+        const rawCommentHtml = buildCommentHtml(user, post, comment, parent);
+        const { html: commentHtml, attachments: commentAttachments } =
+          await inlinePrivateImages(rawCommentHtml);
 
-      try {
-        await transport.sendMail({
-          from: `"Vanguard" <${process.env.SMTP_FROM}>`,
-          to: user.email,
-          subject: subject,
-          replyTo: comment.author.email,
-          sender,
-          text: `View this comment on Vanguard: ${commentUrl}\n\n${comment.content}`,
-          html,
-        });
-      } catch {
-        error("email notification failed");
-      }
-    });
+        try {
+          await transport.sendMail({
+            from: `"Vanguard" <${process.env.SMTP_FROM}>`,
+            to: user.email,
+            subject: subject,
+            replyTo: comment.author.email,
+            sender,
+            text: `View this comment on Vanguard: ${commentUrl}\n\n${comment.content}`,
+            html: commentHtml,
+            attachments: commentAttachments,
+          });
+        } catch {
+          error("email notification failed");
+        }
+      }),
+  );
 };
 
 const buildCommentHtml = (
@@ -238,9 +251,7 @@ const buildCommentHtml = (
       }
       <table cellpadding="0" cellspacing="0" border="0">
         <tr>
-          <td style="vertical-align:top"><img src="${process.env.BASE_URL}${
-            comment.author.picture || `/img/placeholder-avatar.png`
-          }" width="36" height="36" style="border-radius:36px;display:block;" /></td>
+          <td style="vertical-align:top"><img src="${resolveAvatarUrl(comment.author.picture)}" width="36" height="36" style="border-radius:36px;display:block;" /></td>
           <td style="padding-left:15px">
             <table cellpadding="0" cellspacing="0" border="0">
               <tr>


### PR DESCRIPTION
## Problem

Email notifications embed `<img>` tags pointing at `/image-uploads/...`, which is auth-gated by `requireUserId` in `app/routes/image-uploads.$.tsx`. When a recipient's mail client (Gmail's image proxy, Outlook, Apple Mail, etc.) tries to fetch those URLs, it has no session cookie → redirected to `/login` → broken-image icon.

This affects three places in every email:
1. **Author avatars** (when the user uploaded a custom avatar via Settings — stored as `/image-uploads/...` in `users.picture`)
2. **Post body images** uploaded via the editor
3. **Comment-author avatars** in `notifyComment`

Real-world repro: a post sent to `shipped@sentry.io` last night rendered both the author's avatar and an inline screenshot as broken-image icons.

The blobs are stored in Vercel Blob with `access: "private"` — there is **no** public URL to fall back to. Bytes can only be read server-side via `get(pathname, { access: "private" })`. That rules out signed-URL approaches without flipping the privacy model. It also rules out base64 data URIs because Gmail webmail strips them.

## Solution

**CID inline attachments** (RFC 2392, `multipart/related`) — the email-native way to embed images. The bytes go into the MIME envelope as `Content-Disposition: inline` parts; the HTML references them via `<img src="cid:...">`. Renders in every major mail client, isn't subject to Gmail's 102 KB body-clip threshold, and keeps the blobs fully private.

### `app/lib/email-images.ts` (new)

`inlinePrivateImages(html)` helper that:
- Scans for `src="${BASE_URL}/image-uploads/<pathname>"` patterns
- Fetches bytes via `@vercel/blob` `get(..., { access: "private" })` in prod, or `fs.readFile` from `os.tmpdir()` in local dev (mirrors the existing route)
- Deduplicates: same image referenced twice → 1 attachment, both `<img>` share the CID
- Soft-fails per-image (logs `console.warn`, leaves `src` untouched, doesn't break the send)
- Caps at 10 images / 20 MB total to stay well within SMTP message size limits and Vercel function memory

### `app/lib/email.ts`

Wired the helper into both `notify()` and `notifyComment()` send paths.

Also fixed two pre-existing latent bugs that surfaced while writing tests:
- **Avatar URL double-prefix**: old code unconditionally did `${BASE_URL}${author.picture}`, which produced `http://localhost/https://lh3.googleusercontent.com/...` for Google CDN avatars. New `resolveAvatarUrl()` helper leaves absolute URLs untouched, prepends `BASE_URL` only for relative paths.
- **`forEach(async ...)` fire-and-forget** in `notifyComment` — promises were never awaited. Harmless before, but adding real I/O via `inlinePrivateImages` made it surface as test flakiness. Replaced with `await Promise.all([].map(async ...))`.

## Tests

8 new test cases in `app/lib/email.test.ts` (143 tests total, all passing):

1. Single uploaded image → inlined as 1 CID attachment, original URL gone from HTML
2. Two distinct uploaded images → 2 attachments, 2 distinct CIDs
3. Same image referenced twice → 1 attachment, both refs share the CID
4. External `https://example.com/...` URL → left untouched, no attachment
5. Missing file → soft-fails, email still sends, src untouched
6. Custom avatar (`/image-uploads/...`) → inlined as CID
7. Google CDN avatar (`https://lh3...`) → rendered with bare URL, no `${BASE_URL}` prefix, no attachment (proves the avatar-URL bug fix)
8. `notifyComment` with `/image-uploads/...` author picture → inlined

## What's NOT changed

- `image-uploads.$.tsx` stays auth-gated — no change to the on-site privacy model
- Blob `access` mode stays `"private"`
- Slack notifications — out of scope (Slack needs public URLs anyway, separate problem)

## Verification

- `pnpm test` — 143/143 passing ✅
- `pnpm typecheck` — clean ✅
- `vp check` — 0 lint, 0 format issues ✅
