### PR TITLE
feat(markdown): expand prism syntax highlighting language coverage

### DIFF
--- a/app/components/markdown.tsx
+++ b/app/components/markdown.tsx
@@ -3,9 +3,60 @@ import DOMPurify from "isomorphic-dompurify";
 const { sanitize } = DOMPurify;
 import prismjs from "prismjs";
 import { default as summarizeFn } from "../lib/summarize";
+import { error as logError } from "../lib/logging";
 import { useState, useEffect, useRef } from "react";
 
 import "../styles/prism.css";
+
+// Side-effect imports register additional languages on the global Prism
+// namespace. Order matters: a language that `Prism.languages.extend(...)`s or
+// clones another must be loaded *after* its base. Dependency chains here:
+//   clike  -> c -> objectivec
+//   clike  -> javascript -> {jsx, typescript} -> tsx
+//   markup -> {jsx, markdown, markup-templating}
+// The order below respects all of those.
+import "prismjs/components/prism-markup";
+import "prismjs/components/prism-markup-templating";
+import "prismjs/components/prism-clike";
+import "prismjs/components/prism-c";
+import "prismjs/components/prism-objectivec";
+import "prismjs/components/prism-javascript";
+import "prismjs/components/prism-jsx";
+import "prismjs/components/prism-typescript";
+import "prismjs/components/prism-tsx";
+import "prismjs/components/prism-bash";
+import "prismjs/components/prism-css";
+import "prismjs/components/prism-diff";
+import "prismjs/components/prism-git";
+import "prismjs/components/prism-go";
+import "prismjs/components/prism-java";
+import "prismjs/components/prism-json";
+import "prismjs/components/prism-markdown";
+import "prismjs/components/prism-python";
+import "prismjs/components/prism-ruby";
+import "prismjs/components/prism-rust";
+import "prismjs/components/prism-shell-session";
+import "prismjs/components/prism-sql";
+import "prismjs/components/prism-swift";
+import "prismjs/components/prism-yaml";
+
+// Common language aliases users write in fenced code blocks. Anything not
+// listed falls through to a direct lookup, then to plain text.
+const languageAliases: Record<string, string> = {
+  js: "javascript",
+  ts: "typescript",
+  py: "python",
+  rb: "ruby",
+  sh: "bash",
+  zsh: "bash",
+  yml: "yaml",
+  md: "markdown",
+  html: "markup",
+  xml: "markup",
+  svg: "markup",
+  mathml: "markup",
+  objc: "objectivec",
+};
 
 const renderer = new marked.Renderer();
 
@@ -42,15 +93,35 @@ renderer.image = function (href, title, text) {
   return `<figure class="not-prose markdown-figure my-6">${html}</figure>`;
 };
 
+const tryHighlight = (code: string, lang: string): string | null => {
+  const grammar = prismjs.languages[lang];
+  if (!grammar) return null;
+  try {
+    return prismjs.highlight(code, grammar, lang);
+  } catch (e) {
+    logError(e instanceof Error ? e : new Error(String(e)), {
+      context: { component: "markdown", op: "prism.highlight" },
+      tags: { lang },
+    });
+    return null;
+  }
+};
+
 const parseMarkdown = (content: string, options = {}): string => {
   return marked.parse(content, {
     renderer,
     highlight: function (code, lang) {
-      if (prismjs.languages[lang]) {
-        return prismjs.highlight(code, prismjs.languages[lang], lang);
-      } else {
-        return code;
+      if (!lang) return code;
+      const normalized = languageAliases[lang.toLowerCase()] ?? lang.toLowerCase();
+      const highlighted = tryHighlight(code, normalized);
+      if (highlighted !== null) return highlighted;
+      // Fall back to the raw lang token in case it points at a grammar that
+      // isn't reachable via the alias-normalized name.
+      if (normalized !== lang) {
+        const rawHighlighted = tryHighlight(code, lang);
+        if (rawHighlighted !== null) return rawHighlighted;
       }
+      return code;
     },
     breaks: true,
     ...options,

--- a/app/styles/index.css
+++ b/app/styles/index.css
@@ -110,7 +110,11 @@ label.field-inline {
   cursor: pointer;
 }
 
-label.field-required span:before {
+/* Direct-child only: otherwise the asterisk leaks into nested spans the
+ * label happens to wrap (e.g. Prism's `<span class="token …">` tokens that
+ * appear inside the post editor's Preview tab, which lives inside the
+ * required "Content:" label). */
+label.field-required > span:before {
   content: "* ";
   position: absolute;
   left: -1.5ch;


### PR DESCRIPTION
Takes over #155 (`feat: Add syntax highlighting for more languages` by @philprime) and reworks it on top of the post-Drizzle/RR7 main with our current Sentry instrumentation. The original PR no longer rebases cleanly because it touches `prisma/seed.ts` (the prisma tree was removed in #170) and a Prisma-only `db:reset` npm script.

## What's ported

- 24 prismjs language components are now side-effect imported in `app/components/markdown.tsx` covering the languages our internal posts actually use: `js`/`ts`/`tsx`/`jsx`, `python`, `ruby`, `go`, `java`, `rust`, `swift`, `objc`, `c`, `bash`, `shell-session`, `sql`, `yaml`, `json`, `css`, `diff`, `git`, `markdown`, `markup`, `markup-templating`.
- Alias map for the common shorthand fences (`js`→`javascript`, `ts`→`typescript`, `py`→`python`, `sh`/`zsh`→`bash`, `yml`→`yaml`, `md`→`markdown`, `html`/`xml`/`svg`/`mathml`→`markup`, `objc`→`objectivec`, `rb`→`ruby`).
- Each `prism.highlight` call is wrapped in a `tryHighlight` helper that:
  - bails fast on missing/unknown `lang` (falls back to plain code, like before),
  - tries the alias-normalized name first, then falls back to the raw token,
  - catches grammar runtime errors and reports them via `app/lib/logging.ts` (`error()`) so they land in Sentry with the offending `lang` as a tag — instead of #155's silent `console.warn`.

## Import order fix

The PR's original import order would actually crash at module load — `prism-tsx` extends `jsx`, which clones `javascript`, which extends `clike`, and `markup`/`markup-templating` need to be in place too. I reproduced the crash (`TypeError: Cannot set properties of undefined (setting 'comment')`) in a Node smoke test, then ordered the imports to honour every grammar's `extend()` / `clone()` chain. Comment block in the file documents the dependency graph.

## Deliberately dropped from #155

| Upstream change | Why dropped |
|---|---|
| `prisma/seed.ts` — "Code Highlighting Test Document" demo post | The `prisma/` tree no longer exists; equivalent is `drizzle/seed.ts`. Not porting the demo content (per request). |
| `package.json` — `db:reset: npx prisma migrate reset` | Dead on Drizzle. |
| `app/styles/index.css` — `.code-block` → `bg-gray-900` | We already use `bg-[#251f3d]` to match the vendored `prism-sentry` palette (#176), which is a closer fit than the upstream gray. |

## Verification

- `pnpm typecheck` ✓
- `vp lint` ✓ (0 warnings, 0 errors)
- `pnpm build` ✓
- `pnpm test` ✓ (143/143)
- Runtime smoke test in Node: all 22 grammars register and `prismjs.highlight()` emits valid token spans for a representative TS sample.

Closes #155.

Co-authored-by: Philip Niedertscheider <phil.niedertscheider@sentry.io>
