### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: ci
 
+permissions:
+  contents: read
+
 env:
   DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
 


### PR DESCRIPTION
Potential fix for [https://github.com/getsentry/vanguard/security/code-scanning/7](https://github.com/getsentry/vanguard/security/code-scanning/7)

Add an explicit workflow-level `permissions` block in `.github/workflows/build.yml` so all jobs inherit least-privilege token access unless overridden.  
Best minimal fix (without changing functionality) is:

- Add at top level (near `name` / before `env` or before `jobs`):
  - `permissions:`
  - `  contents: read`

This satisfies CodeQL’s recommendation and is typically sufficient for checkout, install, lint, and test operations. No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
