### PR TITLE
fix(ui): drop top margin from clustered post list

### DIFF
--- a/app/components/clustered-post-list.tsx
+++ b/app/components/clustered-post-list.tsx
@@ -21,7 +21,7 @@ export default function ClusteredPostList({
   commentCounts: any;
 }) {
   return (
-    <div className="relative mb-12 mt-16 clustered-post-list">
+    <div className="relative mb-12 clustered-post-list">
       <CategoryTag category={category} />
       <ul>
         {posts.map((post) => {


### PR DESCRIPTION
## Summary

Removes the `mt-16` from `ClusteredPostList`'s container so the cluster spacing is driven solely by `mb-12`. Previously each cluster carried both a top and bottom margin, which double-spaced consecutive clusters and pushed the first cluster too far below the page header.

## Change

```diff
-    <div className="relative mb-12 mt-16 clustered-post-list">
+    <div className="relative mb-12 clustered-post-list">
```

## Verification

- `vp check` ✅
- `pnpm typecheck` ✅