### PR TITLE
feat(ui): morph post titles between list and detail with View Transitions

### DIFF
--- a/app/components/clustered-post-list.tsx
+++ b/app/components/clustered-post-list.tsx
@@ -31,7 +31,7 @@ export default function ClusteredPostList({
           return (
             <li key={post.id} className="clustered-post">
               <IconCollapsedPost className="collapsed-post-icon" />
-              <h3 className="text-3xl font-serif mb-2 break-words">
+              <h3 className="text-4xl font-serif mb-2 break-words">
                 <PostLink post={post} morphTitle>
                   {post.title}
                 </PostLink>

--- a/app/components/clustered-post-list.tsx
+++ b/app/components/clustered-post-list.tsx
@@ -32,7 +32,9 @@ export default function ClusteredPostList({
             <li key={post.id} className="clustered-post">
               <IconCollapsedPost className="collapsed-post-icon" />
               <h3 className="text-3xl font-serif mb-2 break-words">
-                <PostLink post={post}>{post.title}</PostLink>
+                <PostLink post={post} morphTitle>
+                  {post.title}
+                </PostLink>
               </h3>
               <div className="flex flex-1 justify-between items-center gap-2 font-mono text-sm">
                 <Avatar size="24px" user={post.author} />

--- a/app/components/post-link.tsx
+++ b/app/components/post-link.tsx
@@ -1,4 +1,5 @@
-import type { ComponentPropsWithRef } from "react";
+import type { ComponentPropsWithRef, CSSProperties } from "react";
+import { useViewTransitionState } from "react-router";
 import type { Post } from "~/models/post.server";
 import Link from "./link";
 
@@ -6,11 +7,38 @@ export const getPostLink = (post: Post): string => {
   return `/p/${post.id}`;
 };
 
+/**
+ * `morphTitle` opts the link in to a named view transition (`post-<id>`)
+ * while it is the active navigation target. The same component renders the
+ * post title in list views (clustered + summary cards) and on the detail
+ * page, so the matched names line up automatically and the title morphs
+ * across the navigation.
+ *
+ * Only set `morphTitle` on ONE PostLink per post per page (the title) —
+ * multiple elements sharing a `view-transition-name` cause the browser to
+ * abort the transition.
+ */
 export default function PostLink({
   post,
+  morphTitle = false,
+  style,
   ...props
 }: Omit<ComponentPropsWithRef<typeof Link>, "to"> & {
   post: Post;
+  morphTitle?: boolean;
 }) {
-  return <Link color="none" to={getPostLink(post)} {...props} />;
+  const href = getPostLink(post);
+  const isTransitioning = useViewTransitionState(href);
+  const transitionStyle: CSSProperties | undefined =
+    morphTitle && isTransitioning ? { viewTransitionName: `post-${post.id}` } : undefined;
+
+  return (
+    <Link
+      color="none"
+      to={href}
+      viewTransition
+      {...props}
+      style={{ ...transitionStyle, ...style }}
+    />
+  );
 }

--- a/app/components/post-list.tsx
+++ b/app/components/post-list.tsx
@@ -24,7 +24,11 @@ export default function PostList({ postList }) {
               gridArea: "title",
             }}
           >
-            <PostLink className="hover:underline" post={post} morphTitle>
+            {/* No `morphTitle` here — PostList renders in the sidebar on every
+             * page, so a post appearing in both the sidebar and the main feed
+             * would otherwise have two elements claim the same
+             * `view-transition-name` and abort the transition. */}
+            <PostLink className="hover:underline" post={post}>
               {post.title}
             </PostLink>
           </div>

--- a/app/components/post-list.tsx
+++ b/app/components/post-list.tsx
@@ -24,7 +24,7 @@ export default function PostList({ postList }) {
               gridArea: "title",
             }}
           >
-            <PostLink className="hover:underline" post={post}>
+            <PostLink className="hover:underline" post={post} morphTitle>
               {post.title}
             </PostLink>
           </div>

--- a/app/components/post.tsx
+++ b/app/components/post.tsx
@@ -37,7 +37,9 @@ export default function Post({
     <div className="post">
       <CategoryTag category={post.category} />
       <h1 className="font-serif break-words text-4xl mb-6">
-        <PostLink post={post}>{post.title}</PostLink>
+        <PostLink post={post} morphTitle>
+          {post.title}
+        </PostLink>
       </h1>
       <div className="flex font-mono gap-5 mb-6">
         <Avatar user={post.author} />


### PR DESCRIPTION
Wires React Router v7's built-in [View Transitions](https://reactrouter.com/how-to/view-transitions) into `PostLink` so clicking a post smoothly morphs the title from the list into the detail page header.

## What you get

- **Default cross-fade for every post navigation.** `PostLink` now always passes `viewTransition` to the underlying RR `Link`, so all post navigations get the browser's built-in cross-fade for free in Chromium and Safari 18+. Firefox falls through to a normal nav with no breakage.
- **Named title morph from list → detail.** A new opt-in `morphTitle` prop assigns `view-transition-name: post-<id>` to the link **only while it is the active navigation target** (gated on `useViewTransitionState(href)`). The same `Post` component renders both summary cards and the detail `<h1>`, so opting both in makes the names line up automatically.
- **Consistent heading size across the morph.** Bumped the clustered post list `<h3>` from `text-3xl` to `text-4xl` so it matches the detail `<h1>` (and the summary card, which was already `text-4xl`). Without this the morph had to interpolate font size on top of position, which felt distracting.

## Where `morphTitle` is enabled

| Surface | File | Notes |
|---|---|---|
| Detail page `<h1>` | `app/components/post.tsx` | Same component renders summary cards too |
| Summary cards (`/`, `/c/:slug`, `/search`, `/drafts`) | `app/components/post.tsx` | Already `text-4xl`, matches detail |
| Homepage \"shipped\" cluster `<h3>` | `app/components/clustered-post-list.tsx` | Bumped to `text-4xl` to match |

Deliberately **not** enabled on:

- The \"Read more\" PostLink in summary mode (`Post` summary footer) — would collide with the title for the same post on the same page.
- The sidebar `PostList` (`app/components/post-list.tsx`, rendered globally from `app/root.tsx`). Same reason: the recent-posts widget appears on every page, including the very list pages whose cards opt in. Without this guard, a post appearing in both the sidebar and the main feed would have two elements claim the same `view-transition-name`, and the View Transitions API silently aborts when names aren't unique per snapshot. The sidebar still gets the default cross-fade through the inherited `viewTransition` prop.

## Constraint worth knowing

`useViewTransitionState(href)` only flips `true` when the navigation target matches `href`. That means **forward navigation (list → detail) gets the named morph; backward navigation (browser back) gets only the default cross-fade.** This matches the official RR docs example — adding back-nav support is possible but adds complexity and I'd rather do it as a follow-up if the asymmetry is annoying in practice.

## Verification

- `pnpm typecheck` ✅
- `vp check` — 183 files formatted, 171 lint clean ✅
- `pnpm test:vitest` — 143/143 ✅
- Manually testable on `pnpm dev`: click any post on `/` (both the summary card and the shipped cluster items) and watch the title morph into the detail page heading.

## Commits

1. `feat(ui): morph post titles between list and detail with View Transitions` — main wiring
2. `fix(ui): match clustered post-list title size to detail page` — heading size alignment
3. `fix(ui): drop morphTitle from sidebar PostList to avoid name collisions` — fixes the bug where same-post in sidebar + feed silently aborted the transition