### PR TITLE
feat: publish confirm dialog, null-author fix, admin test-email button

### DIFF
--- a/app/components/clustered-post-list.tsx
+++ b/app/components/clustered-post-list.tsx
@@ -8,6 +8,7 @@ import TimeSince from "./timeSince";
 import type { Category } from "~/models/category.server";
 import type { PostQueryType as Post } from "~/models/post.server";
 import Link from "./link";
+import { getDisplayName } from "~/lib/user";
 
 export default function ClusteredPostList({
   category,
@@ -40,9 +41,7 @@ export default function ClusteredPostList({
                 <Avatar size="24px" user={post.author} />
 
                 <div className="font-medium text-base">
-                  <Link to={`/u/${post.author.email}`}>
-                    {post.author.name || post.author.email}
-                  </Link>
+                  <Link to={`/u/${post.author.email}`}>{getDisplayName(post.author)}</Link>
                 </div>
                 <div className="text-gray-500 dark:text-gray-300 flex flex-grow gap-x-2">
                   <Middot />

--- a/app/components/comment-form.tsx
+++ b/app/components/comment-form.tsx
@@ -8,6 +8,7 @@ import Button from "./button";
 import HelpText from "./help-text";
 import { useState } from "react";
 import { Cross1Icon } from "@radix-ui/react-icons";
+import { getDisplayName } from "~/lib/user";
 
 export type CommentFormErrors = {
   comment?: string;
@@ -24,7 +25,7 @@ const ParentComment = ({ comment, onClear }: { comment?: PostComment; onClear: (
     <div className="bg-layer100-light dark:bg-layer100-dark flex px-6 py-3 text-sm rounded-md bold">
       <input type="hidden" name="parentId" value={comment.id} />
       <p className="flex-grow">
-        Replying to <a href={`#c_${comment.id}`}>{comment.author.name || comment.author.email}</a>
+        Replying to <a href={`#c_${comment.id}`}>{getDisplayName(comment.author)}</a>
       </p>
       <Button size="xs" baseStyle="link" onClick={() => onClear()}>
         <Cross1Icon />

--- a/app/components/draft-note.tsx
+++ b/app/components/draft-note.tsx
@@ -1,33 +1,169 @@
-import type { Post } from "~/models/post.server";
+import { useEffect, useRef, useState } from "react";
 import { Form } from "react-router";
+import { ChevronDownIcon } from "@radix-ui/react-icons";
 
-import { getPostLink } from "./post-link";
-import ButtonDropdown, { ButtonDropdownItem } from "./button-dropdown";
+import type { Post } from "~/models/post.server";
+import classNames from "~/lib/classNames";
+import Button from "./button";
 import HelpText from "./help-text";
+import { getPostLink } from "./post-link";
+
+type PublishMode = "announce" | "true";
+
+const COPY: Record<PublishMode, { title: string; body: string; confirmLabel: string }> = {
+  announce: {
+    title: "Publish this post?",
+    body: "This will make the post visible to everyone and send announcements via email and Slack (if configured).",
+    confirmLabel: "Publish",
+  },
+  true: {
+    title: "Publish this post silently?",
+    body: "This will make the post visible to everyone. No announcements will be sent.",
+    confirmLabel: "Publish Silently",
+  },
+};
 
 export default function DraftNote({ post }: { post: Post }) {
+  const [isOpen, setOpen] = useState(false);
+  const [confirming, setConfirming] = useState<PublishMode | null>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const formRef = useRef<HTMLFormElement>(null);
+
+  // Close the dropdown on outside click.
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleClick = (e: Event) => {
+      if (e.target && !dropdownRef.current?.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    window.addEventListener("click", handleClick);
+    return () => window.removeEventListener("click", handleClick);
+  }, [isOpen]);
+
+  // Close the confirm dialog on ESC.
+  useEffect(() => {
+    if (!confirming) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setConfirming(null);
+    };
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [confirming]);
+
+  const openConfirm = (mode: PublishMode) => {
+    setOpen(false);
+    setConfirming(mode);
+  };
+
+  const cancelConfirm = () => setConfirming(null);
+
+  const submitConfirmed = () => {
+    formRef.current?.requestSubmit();
+  };
+
   return (
-    <Form
-      className="rounded-full p-6 bg-violet-900 text-white flex justify-center items-center mb-12 gap-6"
-      method="post"
-      action={`${getPostLink(post)}/edit`}
-    >
-      <p>This post has not been published, and is only visible if you have the link.</p>
-      <ButtonDropdown
-        type="submit"
-        mode="primary"
-        name="published"
-        value="announce"
-        label="Publish"
+    <>
+      <Form
+        ref={formRef}
+        className="rounded-full p-6 bg-violet-900 text-white flex justify-center items-center mb-12 gap-6"
+        method="post"
+        action={`${getPostLink(post)}/edit`}
       >
-        <ButtonDropdownItem type="submit" name="published" value="announce">
-          Publish
-        </ButtonDropdownItem>
-        <ButtonDropdownItem type="submit" name="published" value="true">
-          Publish Silently
-          <HelpText>Don't send announcements (if configured).</HelpText>
-        </ButtonDropdownItem>
-      </ButtonDropdown>
-    </Form>
+        <p>This post has not been published, and is only visible if you have the link.</p>
+
+        {/* Hidden field carries the chosen publish mode through to the action. */}
+        <input type="hidden" name="published" value={confirming ?? ""} />
+
+        <div className="relative" ref={dropdownRef}>
+          <Button
+            type="button"
+            mode="primary"
+            onClick={() => setOpen((v) => !v)}
+            aria-haspopup="menu"
+            aria-expanded={isOpen}
+          >
+            <span className="inline-flex items-center gap-1">
+              Publish
+              <ChevronDownIcon width="16" height="16" />
+            </span>
+          </Button>
+
+          <div
+            role="menu"
+            className={classNames(
+              "whitespace-nowrap text-primary-light dark:text-primary-dark bg-bg-light dark:bg-bg-dark shadow-lg rounded absolute right-0 mt-2 flex-col z-10",
+              isOpen ? "flex" : "hidden",
+            )}
+          >
+            <button
+              type="button"
+              role="menuitem"
+              className="flex flex-col text-left px-4 py-2 cursor-pointer relative rounded-md text-button-default-text-light dark:text-button-default-text-dark bg-button-default-bg-light dark:bg-button-default-bg-dark first:rounded-b-none last:rounded-t-none hover:text-button-primary-text-light dark:hover:text-button-primary-text-dark hover:bg-button-primary-bg-light dark:hover:bg-button-primary-bg-dark"
+              onClick={() => openConfirm("announce")}
+            >
+              Publish
+            </button>
+            <button
+              type="button"
+              role="menuitem"
+              className="flex flex-col text-left px-4 py-2 cursor-pointer relative rounded-md text-button-default-text-light dark:text-button-default-text-dark bg-button-default-bg-light dark:bg-button-default-bg-dark first:rounded-b-none last:rounded-t-none hover:text-button-primary-text-light dark:hover:text-button-primary-text-dark hover:bg-button-primary-bg-light dark:hover:bg-button-primary-bg-dark"
+              onClick={() => openConfirm("true")}
+            >
+              Publish Silently
+              <HelpText>Don't send announcements (if configured).</HelpText>
+            </button>
+          </div>
+        </div>
+      </Form>
+
+      {confirming && (
+        <ConfirmPublishDialog
+          mode={confirming}
+          onCancel={cancelConfirm}
+          onConfirm={submitConfirmed}
+        />
+      )}
+    </>
+  );
+}
+
+function ConfirmPublishDialog({
+  mode,
+  onCancel,
+  onConfirm,
+}: {
+  mode: PublishMode;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  const { title, body, confirmLabel } = COPY[mode];
+
+  return (
+    <div
+      className="fixed inset-0 bg-black bg-opacity-75 flex items-center justify-center z-50 p-4"
+      onClick={onCancel}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="confirm-publish-title"
+    >
+      <div
+        className="bg-bg-light dark:bg-bg-dark text-primary-light dark:text-primary-dark rounded-lg shadow-2xl max-w-md w-full p-6"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 id="confirm-publish-title" className="text-xl font-semibold mb-3">
+          {title}
+        </h2>
+        <p className="mb-6">{body}</p>
+        <div className="flex justify-end gap-3">
+          <Button type="button" mode="default" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button type="button" mode="primary" onClick={onConfirm}>
+            {confirmLabel}
+          </Button>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/app/components/post-comments.tsx
+++ b/app/components/post-comments.tsx
@@ -13,6 +13,7 @@ import IconCollapsedPost from "~/icons/IconCollapsedPost";
 import type { PostCommentWithAuthor as PostComment } from "~/models/post-comments.server";
 import TimeSince from "./timeSince";
 import Link from "./link";
+import { getDisplayName } from "~/lib/user";
 
 const deleteComment = async (postId: string, commentId: string): Promise<string | undefined> => {
   const res = await fetch(`/api/posts/${postId}/comments/${commentId}`, {
@@ -93,9 +94,7 @@ const Comment = ({
         <div className="flex-1 rounded pt-4 px-4 mb-4 bg-layer100-light dark:bg-layer100-dark">
           <div className="flex flex-1 justify-between items-center gap-1 mb-2 w-full">
             <Avatar user={comment.author} size="24px" />
-            <Link to={`/u/${comment.author.email}`}>
-              {comment.author.name || comment.author.email}
-            </Link>
+            <Link to={`/u/${comment.author.email}`}>{getDisplayName(comment.author)}</Link>
             <Middot />
             <div className="text-secondary-light dark:text-secondary-dark">
               <TimeSince date={comment.createdAt} />

--- a/app/components/post-list.tsx
+++ b/app/components/post-list.tsx
@@ -2,6 +2,7 @@ import PostLink from "~/components/post-link";
 import Avatar from "~/components/avatar";
 import TimeSince from "./timeSince";
 import Link from "./link";
+import { getDisplayName } from "~/lib/user";
 
 export default function PostList({ postList }) {
   return (
@@ -42,7 +43,7 @@ export default function PostList({ postList }) {
             }}
           >
             <div className="font-medium text-sm">
-              <Link to={`/u/${post.author.email}`}>{post.author.name || post.author.email}</Link>
+              <Link to={`/u/${post.author.email}`}>{getDisplayName(post.author)}</Link>
             </div>
             <div className="text-xs">
               <TimeSince date={post.publishedAt} />

--- a/app/components/post.tsx
+++ b/app/components/post.tsx
@@ -11,6 +11,7 @@ import { ChatBubbleIcon, HeartIcon } from "@radix-ui/react-icons";
 import TimeSince from "./timeSince";
 import DraftNote from "./draft-note";
 import Link from "./link";
+import SendTestEmailButton from "./send-test-email-button";
 import { getDisplayName } from "~/lib/user";
 
 const URL_REGEXP = new RegExp(
@@ -23,12 +24,14 @@ export default function Post({
   post,
   summary = false,
   canEdit = false,
+  isAdmin = false,
   reactions,
   totalComments,
 }: {
   post: PostType;
   summary?: boolean;
   canEdit?: boolean;
+  isAdmin?: boolean;
   reactions?: any[];
   totalComments?: number;
 }) {
@@ -74,6 +77,12 @@ export default function Post({
               <>
                 <Middot />
                 <Link to={`/p/${post!.id}/edit`}>Edit</Link>
+              </>
+            )}
+            {isAdmin && !summary && (
+              <>
+                <Middot />
+                <SendTestEmailButton postId={post.id} />
               </>
             )}
             {summary && (

--- a/app/components/post.tsx
+++ b/app/components/post.tsx
@@ -11,6 +11,7 @@ import { ChatBubbleIcon, HeartIcon } from "@radix-ui/react-icons";
 import TimeSince from "./timeSince";
 import DraftNote from "./draft-note";
 import Link from "./link";
+import { getDisplayName } from "~/lib/user";
 
 const URL_REGEXP = new RegExp(
   /(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)/g,
@@ -45,7 +46,7 @@ export default function Post({
         <Avatar user={post.author} />
         <div className="flex flex-1 flex-col justify-between">
           <div className="font-medium">
-            <Link to={`/u/${post.author.email}`}>{post.author.name || post.author.email}</Link>
+            <Link to={`/u/${post.author.email}`}>{getDisplayName(post.author)}</Link>
           </div>
           <div className="text-muted-light dark:text-muted-dark flex">
             <div>

--- a/app/components/send-test-email-button.tsx
+++ b/app/components/send-test-email-button.tsx
@@ -1,0 +1,62 @@
+import { useState } from "react";
+
+import Button from "./button";
+
+type Status = "idle" | "sending" | "sent" | "error";
+
+export default function SendTestEmailButton({ postId }: { postId: string }) {
+  const [status, setStatus] = useState<Status>("idle");
+  const [message, setMessage] = useState<string | null>(null);
+
+  const send = async () => {
+    setStatus("sending");
+    setMessage(null);
+    try {
+      const res = await fetch(`/api/posts/${postId}/test-email`, { method: "POST" });
+      const data = (await res.json().catch(() => ({}))) as { to?: string; error?: string };
+      if (!res.ok) {
+        setStatus("error");
+        setMessage(data.error ?? `Request failed (${res.status})`);
+        return;
+      }
+      setStatus("sent");
+      setMessage(data.to ? `Sent to ${data.to}` : "Sent");
+    } catch (err) {
+      setStatus("error");
+      setMessage(err instanceof Error ? err.message : "Network error");
+    }
+  };
+
+  const label =
+    status === "sending"
+      ? "Sending…"
+      : status === "sent"
+        ? "Send another test email"
+        : "Send test email";
+
+  return (
+    <span className="inline-flex items-center gap-2">
+      <Button
+        type="button"
+        baseStyle="link"
+        size="xs"
+        onClick={send}
+        disabled={status === "sending"}
+        title="Send this post's announcement email to your own admin address."
+      >
+        {label}
+      </Button>
+      {message && (
+        <span
+          className={
+            status === "error"
+              ? "text-sm text-red-500"
+              : "text-sm text-muted-light dark:text-muted-dark"
+          }
+        >
+          {message}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/app/lib/email.ts
+++ b/app/lib/email.ts
@@ -10,6 +10,7 @@ import summarize from "./summarize";
 import { inlinePrivateImages } from "./email-images";
 import { lightTheme } from "~/styles/theme";
 import { escapeHtml } from "./html";
+import { getDisplayName } from "./user";
 import { getUserById } from "~/models/user.server";
 import type { User } from "~/models/user.server";
 
@@ -88,7 +89,7 @@ export const notify = async ({
   }
 
   const postUrl = `${process.env.BASE_URL}/p/${post.id}`;
-  const sender = `"${post.author.name || post.author.email}" <${post.author.email}>`;
+  const sender = `"${getDisplayName(post.author)}" <${post.author.email}>`;
   const subject = config.subjectPrefix ? `${config.subjectPrefix} ${post.title}` : post.title;
 
   try {
@@ -141,7 +142,7 @@ const buildPostEmail = (post: PostQueryType): string => {
           <tr>
             <td>
               <b style="color:${lightTheme.textColor};">${escapeHtml(
-                post.author.name || post.author.email,
+                getDisplayName(post.author),
               )}</b>
             </td>
           </tr>
@@ -176,7 +177,7 @@ export const notifyComment = async ({
   }
 
   const commentUrl = `${process.env.BASE_URL}/p/${post.id}#c_${comment.id}`;
-  const sender = `"${comment.author.name || comment.author.email}" <${comment.author.email}>`;
+  const sender = `"${getDisplayName(comment.author)}" <${comment.author.email}>`;
   const subject = `Re: ${post.title}`;
 
   const subscriptions: User[] = await getSubscriptions({ postId: post.id });
@@ -227,8 +228,8 @@ const buildCommentHtml = (
 
   const isInReplyTo = parent && parent.authorId === toUser.id;
   const titleLine = isInReplyTo
-    ? `${escapeHtml(comment.author.name || comment.author.email)} just replied to your comment`
-    : `${escapeHtml(comment.author.name || comment.author.email)} left a new comment`;
+    ? `${escapeHtml(getDisplayName(comment.author))} just replied to your comment`
+    : `${escapeHtml(getDisplayName(comment.author))} left a new comment`;
   const reasonLine = isInReplyTo
     ? `You are being notified because you have notification replies enabled. <a href="${settingsUrl}">Account Settings</a>`
     : `You are being notified because you are subscribed to this post. <a href="${postUrl}">Post Settings</a>`;
@@ -256,7 +257,7 @@ const buildCommentHtml = (
             <table cellpadding="0" cellspacing="0" border="0">
               <tr>
                 <td><b style="color:${lightTheme.textColor};">${escapeHtml(
-                  comment.author.name,
+                  getDisplayName(comment.author),
                 )}</b></td>
               </tr>
               <tr>

--- a/app/lib/slack.ts
+++ b/app/lib/slack.ts
@@ -1,6 +1,7 @@
 import { error } from "./logging";
 import type { PostQueryType } from "~/models/post.server";
 import summarize from "./summarize";
+import { getDisplayName } from "./user";
 
 import dayjs from "dayjs";
 import advancedFormat from "dayjs/plugin/advancedFormat";
@@ -64,7 +65,7 @@ export const notify = async ({ post, config }: { post: PostQueryType; config: Sl
           fields: [
             {
               type: "mrkdwn",
-              text: `*Written by*\n${author.name}`,
+              text: `*Written by*\n${getDisplayName(author)}`,
             },
             {
               type: "mrkdwn",

--- a/app/lib/user.test.ts
+++ b/app/lib/user.test.ts
@@ -1,0 +1,15 @@
+import { getDisplayName } from "./user";
+
+describe("getDisplayName", () => {
+  test("returns name when set", () => {
+    expect(getDisplayName({ name: "Ada Lovelace", email: "ada@example.com" })).toBe("Ada Lovelace");
+  });
+
+  test("falls back to email when name is null", () => {
+    expect(getDisplayName({ name: null, email: "ada@example.com" })).toBe("ada@example.com");
+  });
+
+  test("falls back to email when name is empty string", () => {
+    expect(getDisplayName({ name: "", email: "ada@example.com" })).toBe("ada@example.com");
+  });
+});

--- a/app/lib/user.ts
+++ b/app/lib/user.ts
@@ -1,0 +1,12 @@
+/**
+ * Returns a human-readable display name for a user, falling back to their
+ * email address when no name is set. The `name` column is nullable in the
+ * schema (users created via the basic-auth CLI or OAuth providers that
+ * don't expose a profile name will have `name === null`), so call sites
+ * that need to render an attribution should use this helper instead of
+ * accessing `user.name` directly — otherwise nullable names render as
+ * the literal string "null" in templates.
+ */
+export function getDisplayName(user: { name: string | null; email: string }): string {
+  return user.name || user.email;
+}

--- a/app/routes/api.posts.$postId_.test-email.test.ts
+++ b/app/routes/api.posts.$postId_.test-email.test.ts
@@ -1,0 +1,152 @@
+// @ts-nocheck
+import { vi } from "vitest";
+
+import type { Post } from "~/models/post.server";
+import type { User } from "~/models/user.server";
+import * as email from "~/lib/email";
+import { expectRequiresAdmin, expectRequiresUser } from "~/lib/test/expects";
+import * as Fixtures from "~/lib/test/fixtures";
+import { buildRequest } from "~/lib/test/request";
+
+import { action } from "./api.posts.$postId_.test-email";
+
+describe("POST /api/posts/$postId/test-email", () => {
+  let admin: User;
+  let post: Post;
+  let originalSmtpFrom: string | undefined;
+  let originalBaseUrl: string | undefined;
+
+  beforeEach(async () => {
+    admin = await Fixtures.User({ admin: true });
+    post = await Fixtures.Post({ authorId: admin.id });
+
+    originalSmtpFrom = process.env.SMTP_FROM;
+    originalBaseUrl = process.env.BASE_URL;
+  });
+
+  afterEach(() => {
+    if (originalSmtpFrom === undefined) delete process.env.SMTP_FROM;
+    else process.env.SMTP_FROM = originalSmtpFrom;
+    if (originalBaseUrl === undefined) delete process.env.BASE_URL;
+    else process.env.BASE_URL = originalBaseUrl;
+    vi.restoreAllMocks();
+  });
+
+  it("requires user", async () => {
+    await expectRequiresUser(
+      action({
+        request: await buildRequest(`http://localhost/api/posts/${post.id}/test-email`, {
+          method: "POST",
+        }),
+        params: { postId: post.id },
+        context: {},
+      }),
+    );
+  });
+
+  it("requires admin", async () => {
+    const nonAdmin = await Fixtures.User({ admin: false });
+    await expectRequiresAdmin(
+      action({
+        request: await buildRequest(
+          `http://localhost/api/posts/${post.id}/test-email`,
+          { method: "POST" },
+          { user: nonAdmin },
+        ),
+        params: { postId: post.id },
+        context: {},
+      }),
+    );
+  });
+
+  it("returns 405 for non-POST methods", async () => {
+    const res = await action({
+      request: await buildRequest(
+        `http://localhost/api/posts/${post.id}/test-email`,
+        { method: "GET" },
+        { user: admin },
+      ),
+      params: { postId: post.id },
+      context: {},
+    });
+    expect(res.status).toBe(405);
+  });
+
+  it("returns 404 when post does not exist", async () => {
+    const res = await action({
+      request: await buildRequest(
+        `http://localhost/api/posts/missing/test-email`,
+        { method: "POST" },
+        { user: admin },
+      ),
+      params: { postId: "missing" },
+      context: {},
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 503 when SMTP is not configured", async () => {
+    delete process.env.SMTP_FROM;
+    process.env.BASE_URL = "http://localhost";
+
+    const notifySpy = vi.spyOn(email, "notify").mockResolvedValue(undefined);
+
+    const res = await action({
+      request: await buildRequest(
+        `http://localhost/api/posts/${post.id}/test-email`,
+        { method: "POST" },
+        { user: admin },
+      ),
+      params: { postId: post.id },
+      context: {},
+    });
+
+    expect(res.status).toBe(503);
+    expect(notifySpy).not.toHaveBeenCalled();
+  });
+
+  it("sends the email to the admin and returns ok", async () => {
+    process.env.SMTP_FROM = "vanguard@example.com";
+    process.env.BASE_URL = "http://localhost";
+
+    const notifySpy = vi.spyOn(email, "notify").mockResolvedValue(undefined);
+
+    const res = await action({
+      request: await buildRequest(
+        `http://localhost/api/posts/${post.id}/test-email`,
+        { method: "POST" },
+        { user: admin },
+      ),
+      params: { postId: post.id },
+      context: {},
+    });
+
+    expect(res).toEqual({ ok: true, to: admin.email });
+    expect(notifySpy).toHaveBeenCalledOnce();
+    const call = notifySpy.mock.calls[0][0];
+    expect(call.config.to).toBe(admin.email);
+    expect(call.config.subjectPrefix).toBe("[TEST]");
+    expect(call.post.id).toBe(post.id);
+  });
+
+  it("returns 500 when notify throws", async () => {
+    process.env.SMTP_FROM = "vanguard@example.com";
+    process.env.BASE_URL = "http://localhost";
+
+    vi.spyOn(email, "notify").mockRejectedValue(new Error("smtp boom"));
+    // Suppress console.error from the route's own logging during the throw.
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const res = await action({
+      request: await buildRequest(
+        `http://localhost/api/posts/${post.id}/test-email`,
+        { method: "POST" },
+        { user: admin },
+      ),
+      params: { postId: post.id },
+      context: {},
+    });
+
+    expect(res.status).toBe(500);
+  });
+});

--- a/app/routes/api.posts.$postId_.test-email.ts
+++ b/app/routes/api.posts.$postId_.test-email.ts
@@ -1,0 +1,57 @@
+import type { ActionFunctionArgs } from "react-router";
+import invariant from "tiny-invariant";
+
+import * as email from "~/lib/email";
+import { getPost } from "~/models/post.server";
+import { requireAdmin } from "~/services/auth.server";
+
+/**
+ * Admin-only smoke test for the post-announcement email pipeline.
+ *
+ * Sends the post's announcement email to the calling admin's own address so
+ * they can eyeball rendering — particularly the inline-CID image handling
+ * added in #174 — without having to (re-)trigger a real announcement to the
+ * whole category. Uses the existing `subjectPrefix` knob to mark the message
+ * as `[TEST]` so it can't be confused with a genuine announcement.
+ *
+ * Awaited (not deferred via `waitUntil`) on purpose: we want failures to
+ * surface synchronously so the admin gets immediate feedback in the UI.
+ */
+export async function action({ request, params }: ActionFunctionArgs) {
+  if (request.method !== "POST") {
+    return Response.json({ error: "Method not allowed" }, { status: 405 });
+  }
+  invariant(params.postId, "postId not found");
+
+  const admin = await requireAdmin(request);
+
+  const post = await getPost({ user: admin, id: params.postId });
+  if (!post) {
+    return Response.json({ error: "Post not found" }, { status: 404 });
+  }
+
+  // Pre-flight the same env vars `hasEmailSupport()` checks. Doing it here lets
+  // us return a clear 503 to the UI; otherwise `email.notify` would just log
+  // and silently no-op, leaving the admin guessing why nothing arrived.
+  if (!process.env.SMTP_FROM || !process.env.BASE_URL) {
+    return Response.json(
+      { error: "Email is not configured on this environment." },
+      { status: 503 },
+    );
+  }
+
+  try {
+    await email.notify({
+      post,
+      config: { to: admin.email, subjectPrefix: "[TEST]" },
+    });
+  } catch (err) {
+    console.error(
+      `[api.posts.test-email] notify threw — post=${post.id} to=${admin.email}`,
+      err instanceof Error ? err.message : err,
+    );
+    return Response.json({ error: "Failed to send test email" }, { status: 500 });
+  }
+
+  return { ok: true, to: admin.email };
+}

--- a/app/routes/feeds.$feedId[.]xml.tsx
+++ b/app/routes/feeds.$feedId[.]xml.tsx
@@ -7,6 +7,7 @@ import { marked } from "marked";
 import { escapeCdata, escapeHtml } from "~/lib/html";
 import summarize from "~/lib/summarize";
 import { buildUrl } from "~/lib/http";
+import { getDisplayName } from "~/lib/user";
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
   invariant(params.feedId, "feedId not found");
@@ -42,7 +43,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
                   baseUrl: process.env.BASE_URL,
                 }),
               )}]]></content:encoded>
-              <author>${escapeHtml(post.author.name || post.author.email)}</author>
+              <author>${escapeHtml(getDisplayName(post.author))}</author>
               <pubDate>${post.publishedAt?.toUTCString()}</pubDate>
               <link>${buildUrl(getPostLink(post), request)}</link>
 

--- a/app/routes/p.$postId._index.tsx
+++ b/app/routes/p.$postId._index.tsx
@@ -91,7 +91,7 @@ export default function PostDetailsPage() {
 
   return (
     <div>
-      <PostTemplate post={post} canEdit={canEdit} reactions={reactions} />
+      <PostTemplate post={post} canEdit={canEdit} isAdmin={user.admin} reactions={reactions} />
       {post.published && (
         <>
           <PostReactions post={post} reactions={reactions} />


### PR DESCRIPTION
Three small, independent changes that came up while looking at the post detail page. Each is its own commit so they can be reviewed (or reverted) on their own.

## 1. Confirmation dialog before publishing — `f1b4d8c`

The previous "Publish ⌄" split-button on the draft banner submitted with `published=announce` the moment you clicked the label, firing workspace-wide email + Slack notifications with a single click. The chevron-only "Publish Silently" option was also a discovery problem.

- The button is now a normal button (no split). Clicking anywhere on it always opens the dropdown.
- Both publish modes (`Publish` and `Publish Silently`) are kept — they map to the existing `announce` / `true` server contract.
- Picking either option opens a centered confirm dialog with copy that spells out the consequence (announcements via email + Slack, or no announcements at all). Cancel / ESC / click-outside all dismiss.
- `ButtonDropdown` is left untouched so the split-button save-changes flow in `post-form.tsx` keeps working.

## 2. Fix `Written by null` in Slack notifications — `71ab1e8`

Slack post announcements rendered `Written by null` whenever the post author had no name set (see screenshot the team flagged). The `User.name` column is nullable in Drizzle (`text("name")`, no `.notNull()`), and accounts created via the basic-auth CLI or OAuth providers that don't expose a profile name end up with `name === null` — which JS template literals stringify as the literal string `"null"`. The same latent bug existed in the comment-notification email (`buildCommentHtml`).

- New `app/lib/user.ts` exporting `getDisplayName(user)` taking the minimal `{ name: string | null; email: string }` shape.
- New `app/lib/user.test.ts` covering name-set, name-null, name-empty (the case existing fixtures don't exercise — which is why this slipped past CI in the first place).
- Replaced ad-hoc `name || email` fallbacks with `getDisplayName` across all 9 attribution sites (post / post-list / clustered-post-list / post-comments / comment-form / RSS feed / 4× in `email.ts`).

## 3. Admin "Send test email" button — `53be1ce`

After the inline-CID image rewrite in #174, debugging email rendering meant publishing a real test post and waiting for the fan-out to fire. This adds an admin-only affordance to dogfood the email pipeline against the calling admin's own mailbox, without touching the category fan-out.

- New `POST /api/posts/:postId/test-email` route (`requireAdmin`). Awaits `email.notify` (no `waitUntil`) so failures surface synchronously to the UI. Pre-flights `SMTP_FROM` / `BASE_URL` and returns 503 with a clear message when email isn't configured. Uses the existing `subjectPrefix` knob to mark the message `[TEST]`.
- New `SendTestEmailButton` component in the meta row of the post detail page — only renders when `user.admin && !summary`, so it never leaks into summary cards on the homepage / category pages / drafts. Shows inline status (`Sending…` → `Sent to <admin email>` or `Failed: <reason>`).

## Verification

- `pnpm typecheck` ✅
- `vp check` ✅ (formatting + lint clean across all 188 / 176 files)
- `pnpm test:vitest` — 153/153 passing (was 146 before; +3 for `getDisplayName`, +7 for the new admin route)

## Manual smoke test plan

For the admin button (the main thing you want to verify):

1. Pull this branch, log in as an admin, open any post detail page.
2. Click `Send test email` in the meta row.
3. Confirm an email arrives at your own admin address with subject `[TEST] <post title>`, and that any embedded `/image-uploads/...` images render in the client.
