### PR TITLE
fix(markdown): render lightbox caption below image instead of overlapping

### DIFF
--- a/app/components/markdown.tsx
+++ b/app/components/markdown.tsx
@@ -164,7 +164,7 @@ function ImageModal({
       className="fixed inset-0 bg-black bg-opacity-75 flex items-center justify-center z-50 p-4"
       onClick={onClose}
     >
-      <div className="relative w-full max-w-[95vw] max-h-full flex items-center justify-center">
+      <div className="relative w-full max-w-[95vw] max-h-full flex flex-col items-center">
         <img
           src={src}
           alt={alt}
@@ -179,7 +179,7 @@ function ImageModal({
           ×
         </button>
         {alt && (
-          <div className="absolute bottom-4 left-4 right-4 text-white text-center bg-black bg-opacity-70 rounded px-4 py-3 text-sm">
+          <div className="w-full text-white text-center bg-black bg-opacity-70 rounded px-4 py-3 text-sm mt-2">
             {alt}
           </div>
         )}

--- a/app/components/markdown.tsx
+++ b/app/components/markdown.tsx
@@ -164,11 +164,11 @@ function ImageModal({
       className="fixed inset-0 bg-black bg-opacity-75 flex items-center justify-center z-50 p-4"
       onClick={onClose}
     >
-      <div className="relative w-full max-w-[95vw] max-h-full flex flex-col items-center">
+      <div className="relative w-full max-w-[95vw] max-h-[90vh] flex flex-col items-center">
         <img
           src={src}
           alt={alt}
-          className="w-full max-h-[90vh] object-contain rounded-lg shadow-2xl"
+          className="w-full min-h-0 flex-1 object-contain rounded-lg shadow-2xl"
           onClick={(e) => e.stopPropagation()}
         />
         <button
@@ -179,7 +179,7 @@ function ImageModal({
           ×
         </button>
         {alt && (
-          <div className="w-full text-white text-center bg-black bg-opacity-70 rounded px-4 py-3 text-sm mt-2">
+          <div className="w-full flex-shrink-0 text-white text-center bg-black bg-opacity-70 rounded px-4 py-3 text-sm mt-2">
             {alt}
           </div>
         )}


### PR DESCRIPTION
The caption bar in the image lightbox was absolutely positioned inside the same container as the image, so it always overlapped the bottom of the image. The fix switches the container to a flex column layout capped at 90vh, with the image flex-growing to fill available space, so the caption always renders beneath the image regardless of aspect ratio.

Preview of the fix https://vanguard-git-joshua-fixcaptionbelowimage.sentry.dev/p/oo0e7ej0eq8wz1y688kagexo

Since there is now some padding & the caption is rendered below the image, the image itself is slightly smaller to fit onto the screen besides the other elements. If that is unwanted behavior, maybe we just switch the caption to be semi-transparent to keep it on top of the image?

---

## Before fix

On large images, the bottom gets cut off by the alt text:
<img width="1837" height="641" alt="Screenshot 2026-05-04 at 17 45 04" src="https://github.com/user-attachments/assets/5a9109f0-45c2-434c-8224-58ac8bda6d52" />

Which could lose some information on the bottom of an image

<img width="1109" height="405" alt="Screenshot 2026-05-04 at 17 47 25" src="https://github.com/user-attachments/assets/20d7c438-64b6-4643-9afb-faf6afb69769" />

## Fixed example
<img width="1828" height="710" alt="Screenshot 2026-05-04 at 17 51 38" src="https://github.com/user-attachments/assets/9c5f145e-90bd-4960-be15-bf495ed17623" />


Co-authored-by: Claude (Sonnet 4.6) <noreply@anthropic.com>