### PR TITLE
fix(markdown): drop data-* URL round-trip flagged by CodeQL js/xss-through-dom

### DIFF
--- a/app/components/markdown.tsx
+++ b/app/components/markdown.tsx
@@ -71,7 +71,12 @@ renderer.code = function (code, lang, _escaped) {
   return `<pre class="code-block ${langClass}"><code class="${langClass}">${code}</code></pre>`;
 };
 
-// add captions to images with enlargeable functionality
+// add captions to images with enlargeable functionality.
+// IMPORTANT: don't stash the URL in a custom data-* attribute — DOMPurify
+// only URL-sanitizes well-known attributes (src/href/xlink:href). Anything in
+// data-* is treated as inert text and would let a `javascript:` URL survive
+// sanitization and round-trip back into a sink. The click handler reads the
+// already-sanitized `src`/`title`/`alt` attributes off the rendered <img>.
 renderer.image = function (href, title, text) {
   const imgId = `img-${Math.random().toString(36).substr(2, 9)}`;
   const html = `<img 
@@ -80,8 +85,6 @@ renderer.image = function (href, title, text) {
     title="${title || ""}" 
     alt="${text}" 
     class="markdown-image cursor-pointer hover:opacity-80 transition-opacity max-w-full h-auto rounded-lg shadow-sm"
-    data-enlarge-src="${href}"
-    data-enlarge-alt="${title || text || ""}"
   />`;
 
   if (title) {
@@ -209,11 +212,14 @@ export default function Markdown({
 
     const handleImageClick = (event: Event) => {
       const target = event.target as HTMLElement;
-      if (target.tagName === "IMG" && target.classList.contains("markdown-image")) {
-        const src = target.getAttribute("data-enlarge-src");
-        const alt = target.getAttribute("data-enlarge-alt");
+      if (target instanceof HTMLImageElement && target.classList.contains("markdown-image")) {
+        // Read from the DOMPurify-sanitized attributes the browser parsed off
+        // the <img> itself — never from custom data-* (which DOMPurify does
+        // not URL-sanitize). `target.src` is the resolved absolute URL.
+        const src = target.src;
+        const alt = target.title || target.alt || "";
         if (src) {
-          setModalImage({ src, alt: alt || "" });
+          setModalImage({ src, alt });
         }
       }
     };


### PR DESCRIPTION
Closes the CodeQL alert at https://github.com/getsentry/vanguard/security/code-scanning/8.

## What was happening

The image lightbox in `app/components/markdown.tsx` was round-tripping the image URL through a custom `data-enlarge-src` attribute:

1. `renderer.image` emitted `<img src="${href}" ... data-enlarge-src="${href}" data-enlarge-alt="${title || text}">`.
2. The HTML went through `DOMPurify.sanitize()`. DOMPurify URL-sanitizes well-known attributes (`src`, `href`, `xlink:href`, …) but **leaves arbitrary `data-*` attributes as inert text** — it does not run URL sanitization on them.
3. The click handler then read `target.getAttribute("data-enlarge-src")` and fed the result into a fresh React `<img src={src} />` in the modal.

So a payload like `![x](javascript:alert(1) "t")` had its `src=""` scrubbed by DOMPurify but `data-enlarge-src="javascript:alert(1)"` survived intact and got reflected back into a sink. CodeQL's `js/xss-through-dom` rule traced exactly that flow:

- **Source** — `markdown.tsx:213` `target.getAttribute("data-enlarge-src")`
- **Sink** — `markdown.tsx:169` `<img src={src} ... />` in `ImageModal`

In *this* particular sink the bug is mostly defanged: browsers do not execute `javascript:` URLs on `<img>`, and React additionally rewrites them. But the round-trip pattern is the actual issue — any future change to the modal (anchor `href`, iframe `src`, `innerHTML`/`setAttribute` to a different sink) would re-introduce a real XSS. The CodeQL rule is right to flag it.

## The fix

Stop round-tripping URLs through unsanitized `data-*` attributes. The `<img>` already carries DOMPurify-sanitized `src`, `title`, and `alt`; just read those.

- `renderer.image` no longer emits `data-enlarge-src` / `data-enlarge-alt`.
- The click handler now reads `target.src` / `target.title` / `target.alt` off the rendered `HTMLImageElement` — the resolved, sanitized values.
- Tightened the type guard from `tagName === "IMG"` to `instanceof HTMLImageElement` so the handler gets a properly typed reference without an unchecked cast.

## Verification

- `pnpm typecheck` ✅
- `vp lint app/components/markdown.tsx` ✅
- Manual: image markdown still renders, click-to-enlarge modal still opens with the correct image and caption (`title` preferred, falling back to `alt`).
- CodeQL: alert #8 should auto-resolve once the next scan runs against this branch / after merge to `main`.