### PR TITLE
feat(slack): include Slack user mention in post notifications

### DIFF
--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -13,6 +13,7 @@ export const users = pgTable("User", {
   canPostRestricted: boolean("canPostRestricted").notNull().default(false),
   admin: boolean("admin").notNull().default(false),
   notifyReplies: boolean("notifyReplies").notNull().default(true),
+  slackUserId: text("slackUserId"),
 });
 
 export const categories = pgTable("Category", {

--- a/app/lib/slack.ts
+++ b/app/lib/slack.ts
@@ -65,7 +65,7 @@ export const notify = async ({ post, config }: { post: PostQueryType; config: Sl
           fields: [
             {
               type: "mrkdwn",
-              text: `*Written by*\n${getDisplayName(author)}`,
+              text: `*Written by*\n${author.slackUserId ? `<@${author.slackUserId}>` : getDisplayName(author)}`,
             },
             {
               type: "mrkdwn",

--- a/app/models/post.server.ts
+++ b/app/models/post.server.ts
@@ -32,7 +32,7 @@ export type Feed = typeof feeds.$inferSelect;
 export type PublicFeed = Omit<Feed, "webhookUrl">;
 
 /** Public author shape embedded in loader-facing post/feed responses. */
-export type PostAuthor = Pick<User, "id" | "email" | "name" | "picture">;
+export type PostAuthor = Pick<User, "id" | "email" | "name" | "picture" | "slackUserId">;
 
 export interface PostQueryType extends Post {
   author: PostAuthor;

--- a/app/models/user.server.ts
+++ b/app/models/user.server.ts
@@ -35,6 +35,7 @@ export const PUBLIC_USER_COLUMNS = {
   email: true,
   name: true,
   picture: true,
+  slackUserId: true,
 } as const;
 
 export async function getUserById(id: User["id"]) {
@@ -164,6 +165,7 @@ export async function updateUser({
   picture?: User["picture"] | null;
   canPostRestricted?: User["canPostRestricted"] | undefined;
   notifyReplies?: User["notifyReplies"] | undefined;
+  slackUserId?: User["slackUserId"] | null;
 }) {
   // When the actor is editing their own row, we already have the latest copy.
   // Otherwise (admin editing another user) load the target so we can diff.
@@ -183,6 +185,8 @@ export async function updateUser({
   if (picture !== undefined) data.picture = picture;
   if (notifyReplies !== undefined && notifyReplies !== target.notifyReplies)
     data.notifyReplies = !!notifyReplies;
+  if (slackUserId !== undefined && slackUserId !== target.slackUserId)
+    data.slackUserId = slackUserId || null;
 
   if (Object.keys(data).length === 0) {
     return target;

--- a/app/routes/u.$userEmail._index.tsx
+++ b/app/routes/u.$userEmail._index.tsx
@@ -68,12 +68,20 @@ export async function action({ request, params }: ActionFunctionArgs) {
   if (formData.get("admin") === "false") {
     await updateUser({ actor: currentUser, id: user.id, admin: false });
   }
+  if (formData.has("slackUserId")) {
+    const slackUserId = formData.get("slackUserId");
+    await updateUser({
+      actor: currentUser,
+      id: user.id,
+      slackUserId: typeof slackUserId === "string" ? slackUserId.trim() || null : null,
+    });
+  }
   return null;
 }
 
-const UserAdmin: React.FC<{ user: { id: string; admin: boolean; canPostRestricted: boolean } }> = ({
-  user,
-}) => {
+const UserAdmin: React.FC<{
+  user: { id: string; admin: boolean; canPostRestricted: boolean; slackUserId: string | null };
+}> = ({ user }) => {
   return (
     <Panel.Panel>
       <Panel.Title>Admin</Panel.Title>
@@ -102,6 +110,22 @@ const UserAdmin: React.FC<{ user: { id: string; admin: boolean; canPostRestricte
             )}
           </li>
         </ul>
+      </Form>
+      <Form method="post" className="mt-4 flex items-center gap-2">
+        <label htmlFor="slackUserId" className="text-sm font-medium">
+          Slack User ID
+        </label>
+        <input
+          id="slackUserId"
+          name="slackUserId"
+          type="text"
+          defaultValue={user.slackUserId ?? ""}
+          placeholder="U0XXXXXXXXX"
+          className="input input-sm"
+        />
+        <Button type="submit" baseStyle="default">
+          Save
+        </Button>
       </Form>
     </Panel.Panel>
   );

--- a/drizzle/0001_add_user_slack_user_id.sql
+++ b/drizzle/0001_add_user_slack_user_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "User" ADD COLUMN "slackUserId" text;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1777023779397,
       "tag": "0000_wise_nebula",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1781643900000,
+      "tag": "0001_add_user_slack_user_id",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## What

Adds a `slackUserId` field to the `User` model so that Slack post notifications include a proper `<@USERID>` mention instead of a plain display name. This makes the mention clickable in Slack and notifies the author.

## Changes

- **`app/db/schema.ts`** — nullable `slackUserId text` column on `User`
- **`app/models/user.server.ts`** — exposes `slackUserId` in `PUBLIC_USER_COLUMNS` and `updateUser()`
- **`app/models/post.server.ts`** — adds `slackUserId` to `PostAuthor` type
- **`app/lib/slack.ts`** — `notify()` uses `<@slackUserId>` when set, falls back to `getDisplayName()`
- **`app/routes/u.$userEmail._index.tsx`** — admin user profile page gets a "Slack User ID" input
- **`drizzle/0001_add_user_slack_user_id.sql`** — migration: `ALTER TABLE "User" ADD COLUMN "slackUserId" text`

## How to set a user's Slack ID

Admins can set it via the user profile page (`/u/<email>`) → Admin panel → Slack User ID field. The ID format is e.g. `U03SQM83ML2`.

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC03PJBM6B8S%3A1781643735.382999%22)