### PR TITLE
build(deps): Bump form-data override to 4.0.6 for CRLF advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
   "packageManager": "pnpm@10.4.1",
   "pnpm": {
     "overrides": {
-      "form-data": "4.0.4",
+      "form-data": "4.0.6",
       "axios": "1.15.0",
       "rollup": "4.60.2",
       "qs": "6.15.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  form-data: 4.0.4
+  form-data: 4.0.6
   axios: 1.15.0
   rollup: 4.60.2
   qs: 6.15.2
@@ -2996,8 +2996,8 @@ packages:
   flairup@1.0.0:
     resolution: {integrity: sha512-IKlE+pNvL2R+kVL1kEhUYqRxVqeFnjiIvHWDMLFXNaqyUdFXQM2wte44EfMYJNHkW16X991t2Zg8apKkhv7OBA==}
 
-  form-data@4.0.4:
-    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   forwarded-parse@2.1.2:
@@ -3072,6 +3072,10 @@ packages:
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   html-encoding-sniffer@4.0.0:
@@ -6456,7 +6460,7 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   esbuild@0.18.20:
     optionalDependencies:
@@ -6634,12 +6638,12 @@ snapshots:
 
   flairup@1.0.0: {}
 
-  form-data@4.0.4:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   forwarded-parse@2.1.2: {}
@@ -6717,6 +6721,10 @@ snapshots:
       has-symbols: 1.1.0
 
   hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 
@@ -6817,7 +6825,7 @@ snapshots:
       cssstyle: 4.0.1
       data-urls: 5.0.0
       decimal.js: 10.4.3
-      form-data: 4.0.4
+      form-data: 4.0.6
       html-encoding-sniffer: 4.0.0
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.4


### PR DESCRIPTION
Bumps the pnpm `form-data` override from 4.0.4 to 4.0.6 to clear a high-severity CRLF injection (GHSA-hmw2-7cc7-3qxx / CVE-2026-12143), which affects `form-data >= 4.0.0, < 4.0.6` via unescaped multipart field names and filenames.

form-data is purely transitive — all reported paths (`isomorphic-dompurify`, `vite-plus`, `vitest`) funnel through a single dependent, `jsdom@24.0.0`, and it is force-resolved by the `pnpm.overrides` entry added in #187, which was simply frozen at the now-vulnerable 4.0.4.

Bumping a dependent does not fix this, so the override is the right lever: jsdom's declared range is already `^4.0.0`, which spans both vulnerable and patched versions, and jsdom is itself transitive and peer-pinned by the test tooling — no dependent bump forces 4.0.6, and a plain install keeps the locked 4.0.4 because it still satisfies the range. `pnpm.overrides` is pnpm's supported mechanism for pinning a purely-transitive dependency.

The lockfile diff is scoped to form-data plus its own subtree (`hasown` 2.0.2 → 2.0.4, pulled in by form-data 4.0.6's `es-set-tostringtag`).

Fixes GHSA-hmw2-7cc7-3qxx