### PR TITLE
Mention post authors in Slack notifications via GibPotato

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,9 @@ SLACK_USERNAME=Vanguard
 SLACK_ICON_URL=
 # Override default channel
 SLACK_CHANNEL=
+# GibPotato API key — resolves post authors' emails to Slack user IDs so
+# notifications @mention the author. Optional; omit to fall back to plain names.
+GIBPOTATO_API_KEY=
 
 # ── Sentry ────────────────────────────────────────────────────────────────────
 # Server-side DSN (used by instrument.server.mjs and entry.server.tsx).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,7 +229,7 @@ See `.env.example` for the full current list. High level:
 | Auth     | `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_HD`                                                |
 | Storage  | `BLOB_READ_WRITE_TOKEN` (run `vercel env pull` after linking)                                          |
 | Email    | `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, `SMTP_FROM`                                        |
-| Slack    | `SLACK_WEBHOOK_URL`, `SLACK_CHANNEL`, `SLACK_USERNAME`, `SLACK_ICON_URL`                               |
+| Slack    | `SLACK_WEBHOOK_URL`, `SLACK_CHANNEL`, `SLACK_USERNAME`, `SLACK_ICON_URL`, `GIBPOTATO_API_KEY`          |
 | Sentry   | `SENTRY_DSN` (server), `VITE_SENTRY_DSN` (client), `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT` |
 
 ## Testing

--- a/app/lib/gibpotato.test.ts
+++ b/app/lib/gibpotato.test.ts
@@ -5,6 +5,10 @@ import { getSlackUserId } from "./gibpotato";
 const USERS = [
   { slack_user_id: "U111", slack_email: "alice@example.com" },
   { slack_user_id: "U222", slack_email: "Bob@Example.com" },
+  { slack_user_id: "U333", slack_email: "chris@example.com" },
+  { slack_user_id: "U444", slack_email: "dana.smith@example.com" },
+  { slack_user_id: "U555", slack_email: "erin.jones@example.com" },
+  { slack_user_id: "U666", slack_email: "erin.brook@example.com" },
 ];
 
 describe("getSlackUserId", () => {
@@ -39,6 +43,31 @@ describe("getSlackUserId", () => {
   test("returns null when no user matches", async () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(Response.json(USERS)));
     expect(await getSlackUserId("nobody@example.com")).toBeNull();
+  });
+
+  test("fuzzy-matches full-name email to first-name-only slack email", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(Response.json(USERS)));
+    expect(await getSlackUserId("chris.jannings@example.com")).toBe("U333");
+  });
+
+  test("fuzzy-matches first-name-only email to full-name slack email", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(Response.json(USERS)));
+    expect(await getSlackUserId("dana@example.com")).toBe("U444");
+  });
+
+  test("prefers the exact match over fuzzy candidates", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(Response.json(USERS)));
+    expect(await getSlackUserId("erin.jones@example.com")).toBe("U555");
+  });
+
+  test("returns null when the fuzzy match is ambiguous", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(Response.json(USERS)));
+    expect(await getSlackUserId("erin@example.com")).toBeNull();
+  });
+
+  test("does not fuzzy-match across domains", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(Response.json(USERS)));
+    expect(await getSlackUserId("chris.jannings@other.com")).toBeNull();
   });
 
   test("returns null when GIBPOTATO_API_KEY is not set", async () => {

--- a/app/lib/gibpotato.test.ts
+++ b/app/lib/gibpotato.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { getSlackUserId } from "./gibpotato";
+
+const USERS = [
+  { slack_user_id: "U111", slack_email: "alice@example.com" },
+  { slack_user_id: "U222", slack_email: "Bob@Example.com" },
+];
+
+describe("getSlackUserId", () => {
+  beforeEach(() => {
+    process.env.GIBPOTATO_API_KEY = "test-key";
+  });
+
+  afterEach(() => {
+    delete process.env.GIBPOTATO_API_KEY;
+    vi.unstubAllGlobals();
+  });
+
+  test("returns the slack user id for a matching email", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(Response.json(USERS)));
+    expect(await getSlackUserId("alice@example.com")).toBe("U111");
+  });
+
+  test("matches emails case-insensitively", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(Response.json(USERS)));
+    expect(await getSlackUserId("bob@example.com")).toBe("U222");
+  });
+
+  test("sends the bearer token", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(Response.json(USERS));
+    vi.stubGlobal("fetch", fetchMock);
+    await getSlackUserId("alice@example.com");
+    expect(fetchMock).toHaveBeenCalledWith("https://gibpotato.app/api/users", {
+      headers: { Authorization: "Bearer test-key" },
+    });
+  });
+
+  test("returns null when no user matches", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(Response.json(USERS)));
+    expect(await getSlackUserId("nobody@example.com")).toBeNull();
+  });
+
+  test("returns null when GIBPOTATO_API_KEY is not set", async () => {
+    delete process.env.GIBPOTATO_API_KEY;
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    expect(await getSlackUserId("alice@example.com")).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("returns null on a non-200 response", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("nope", { status: 401 })));
+    expect(await getSlackUserId("alice@example.com")).toBeNull();
+  });
+
+  test("returns null when fetch throws", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
+    expect(await getSlackUserId("alice@example.com")).toBeNull();
+  });
+});

--- a/app/lib/gibpotato.ts
+++ b/app/lib/gibpotato.ts
@@ -2,6 +2,15 @@ import { error } from "./logging";
 
 const GIBPOTATO_USERS_URL = "https://gibpotato.app/api/users";
 
+/**
+ * Reduces an email to `<first dot-segment of local part>@<domain>` so that
+ * "chris.jannings@sentry.io" and "chris@sentry.io" produce the same key.
+ */
+function firstNameKey(email: string): string {
+  const [local, domain] = email.split("@");
+  return `${local.split(".")[0]}@${domain}`;
+}
+
 type GibPotatoUser = {
   slack_user_id: string;
   slack_email: string;
@@ -13,6 +22,13 @@ type GibPotatoUser = {
  * post author as a real Slack @mention in notifications — which is also what
  * lets GibPotato award potatoes to the author when people react to the
  * message.
+ *
+ * Matching is exact first, then falls back to a fuzzy first-name match:
+ * some people's Slack email only uses their first name (chris@sentry.io)
+ * while Vanguard has the full form (chris.jannings@sentry.io) — or vice
+ * versa. The fuzzy pass compares the first dot-segment of the local part
+ * plus the domain, and only accepts a single unambiguous candidate (two
+ * "chris"es → no match, never mention the wrong person).
  *
  * Fails soft by design: a missing `GIBPOTATO_API_KEY`, a non-200 response,
  * a network error, or an unmatched email all return `null`. A Slack
@@ -41,14 +57,24 @@ export async function getSlackUserId(email: string): Promise<string | null> {
 
     const users = (await res.json()) as GibPotatoUser[];
     const needle = email.toLowerCase();
-    const match = users.find((u) => u.slack_email?.toLowerCase() === needle);
+    const exact = users.find((u) => u.slack_email?.toLowerCase() === needle);
+    if (exact) return exact.slack_user_id;
 
-    if (!match) {
-      console.log(`[gibpotato] no user matched email=${email}`);
-      return null;
+    const needleKey = firstNameKey(needle);
+    const fuzzy = users.filter(
+      (u) => u.slack_email && firstNameKey(u.slack_email.toLowerCase()) === needleKey,
+    );
+    if (fuzzy.length === 1) {
+      console.log(
+        `[gibpotato] fuzzy first-name match — email=${email} slack_email=${fuzzy[0].slack_email}`,
+      );
+      return fuzzy[0].slack_user_id;
     }
 
-    return match.slack_user_id;
+    console.log(
+      `[gibpotato] no user matched email=${email}${fuzzy.length > 1 ? ` (fuzzy match ambiguous — ${fuzzy.length} candidates)` : ""}`,
+    );
+    return null;
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     console.error(`[gibpotato] users request threw — ${message}`);

--- a/app/lib/gibpotato.ts
+++ b/app/lib/gibpotato.ts
@@ -1,0 +1,61 @@
+import { error } from "./logging";
+
+const GIBPOTATO_USERS_URL = "https://gibpotato.app/api/users";
+
+type GibPotatoUser = {
+  slack_user_id: string;
+  slack_email: string;
+};
+
+/**
+ * Resolves a Vanguard user's email address to their Slack user ID via the
+ * GibPotato API (`GET /api/users`, Bearer-token auth). Used to render the
+ * post author as a real Slack @mention in notifications — which is also what
+ * lets GibPotato award potatoes to the author when people react to the
+ * message.
+ *
+ * Fails soft by design: a missing `GIBPOTATO_API_KEY`, a non-200 response,
+ * a network error, or an unmatched email all return `null`. A Slack
+ * notification must never be dropped because GibPotato is unavailable.
+ */
+export async function getSlackUserId(email: string): Promise<string | null> {
+  const apiKey = process.env.GIBPOTATO_API_KEY;
+  if (!apiKey) {
+    console.log("[gibpotato] GIBPOTATO_API_KEY not set — skipping Slack ID lookup");
+    return null;
+  }
+
+  try {
+    const res = await fetch(GIBPOTATO_USERS_URL, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+
+    if (!res.ok) {
+      console.error(`[gibpotato] users request failed — status=${res.status}`);
+      error("gibpotato users request failed", {
+        context: {},
+        tags: { statusCode: res.status },
+      });
+      return null;
+    }
+
+    const users = (await res.json()) as GibPotatoUser[];
+    const needle = email.toLowerCase();
+    const match = users.find((u) => u.slack_email?.toLowerCase() === needle);
+
+    if (!match) {
+      console.log(`[gibpotato] no user matched email=${email}`);
+      return null;
+    }
+
+    return match.slack_user_id;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`[gibpotato] users request threw — ${message}`);
+    error(err instanceof Error ? err : new Error(message), {
+      context: { source: "gibpotato.getSlackUserId" },
+      tags: {},
+    });
+    return null;
+  }
+}

--- a/app/lib/slack.ts
+++ b/app/lib/slack.ts
@@ -15,7 +15,15 @@ export type SlackConfig = {
   iconUrl?: string;
 };
 
-export const notify = async ({ post, config }: { post: PostQueryType; config: SlackConfig }) => {
+export const notify = async ({
+  post,
+  config,
+  authorSlackId,
+}: {
+  post: PostQueryType;
+  config: SlackConfig;
+  authorSlackId?: string | null;
+}) => {
   const { author, category } = post;
   console.log(
     `[slack.notify] start — post=${post.id} category=${category.name} webhookHost=${(() => {
@@ -65,7 +73,7 @@ export const notify = async ({ post, config }: { post: PostQueryType; config: Sl
           fields: [
             {
               type: "mrkdwn",
-              text: `*Written by*\n${getDisplayName(author)}`,
+              text: `*Written by*\n${authorSlackId ? `<@${authorSlackId}>` : getDisplayName(author)}`,
             },
             {
               type: "mrkdwn",

--- a/app/models/post.server.ts
+++ b/app/models/post.server.ts
@@ -3,6 +3,7 @@ import { and, eq, inArray, or, sql } from "drizzle-orm";
 
 import * as email from "../lib/email";
 import * as slack from "../lib/slack";
+import { getSlackUserId } from "../lib/gibpotato";
 import { db } from "~/db/client";
 import {
   categories,
@@ -102,8 +103,14 @@ export function announcePost(post: PostQueryType): void {
             `[announcePost] no per-category Slack rows AND no SLACK_WEBHOOK_URL — Slack fanout will be a no-op`,
           );
         }
+        const authorSlackId = slackConfig.length ? await getSlackUserId(post.author.email) : null;
+        console.log(
+          `[announcePost] gibpotato lookup — post=${post.id} authorSlackId=${authorSlackId ?? "<none>"}`,
+        );
         await Promise.all(
-          slackConfig.map((config) => slack.notify({ post, config: config as slack.SlackConfig })),
+          slackConfig.map((config) =>
+            slack.notify({ post, config: config as slack.SlackConfig, authorSlackId }),
+          ),
         );
         console.log(`[announcePost] waitUntil finished — post ${post.id}`);
       } catch (err) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,6 +35,15 @@ export default defineConfig((config) => ({
   optimizeDeps: {
     exclude: ["react-router-dom"],
   },
+  server: {
+    watch: {
+      // 1Password keeps re-syncing `.env`, and Vite restarts the dev server
+      // on every env-file change (they're explicitly added to the chokidar
+      // watchlist). Ignore them: env values are read once at startup, and a
+      // manual dev-server restart picks up changes when actually needed.
+      ignored: ["**/.env", "**/.env.*"],
+    },
+  },
   plugins: [tailwindcss(), reactRouter(), sentryReactRouter(sentryConfig, config)],
   // Pre-commit checks run via `vp staged` (installed by `vp config`).
   // Auto-fix lint + format on staged source files; fixes are re-staged.


### PR DESCRIPTION
Slack notifications for new posts now @mention the author instead of showing a plain name. We resolve the author's email to their Slack user ID through the GibPotato API (`GIBPOTATO_API_KEY`), so reacting with :potato: on the message rewards the author.

Falls back to the plain display name if GibPotato is unavailable or the email doesn't match.

Also: the dev server no longer restarts every time 1Password re-syncs `.env`.